### PR TITLE
Bacta Grenade Script Rework

### DIFF
--- a/BNA_KC_Scripts/Data/Functions/Medical/fn_areaSlowHeal.sqf
+++ b/BNA_KC_Scripts/Data/Functions/Medical/fn_areaSlowHeal.sqf
@@ -6,7 +6,7 @@
  * object: Object - The object to become a healing area.
  *
  * Return Value:
- * Number - If an error occurs.
+ * None
  *
  * Examples:
  * init = "(_this select 0) call BNAKC_fnc_areaSlowHeal;";
@@ -24,16 +24,24 @@ if (CBA_missionTime == 0) then
     waitUntil {sleep 3; CBA_missionTime > 0;};
 };
 
-// Early exit if object does not have a radius set
-if !(isNumber (configFile >> "CfgVehicles" >> typeOf _object >> "BNA_KC_Medical_areaHealRadius")) exitWith
-{
-    "This object does not have a healing radius set." call BNAKC_fnc_devLog;
-    -1;
-};
-
-_healRadius = getNumber (configFile >> "CfgVehicles" >> typeOf _object >> "BNA_KC_Medical_areaHealRadius");
-_healRate = getNumber (configFile >> "CfgVehicles" >> typeOf _object >> "BNA_KC_Medical_areaHealRate");
-_maxPatients = getNumber (configFile >> "CfgVehicles" >> typeOf _object >> "BNA_KC_Medical_areaHealMaxPatients");
+_healRadius =
+[
+    configFile >> "CfgVehicles" >> typeOf _object,
+    "BNA_KC_Medical_areaHealRadius",
+    7
+] call BIS_fnc_returnConfigEntry;
+_healRate =
+[
+    configFile >> "CfgVehicles" >> typeOf _object,
+    "BNA_KC_Medical_areaHealRate",
+    6
+] call BIS_fnc_returnConfigEntry;
+_maxPatients =
+[
+    configFile >> "CfgVehicles" >> typeOf _object,
+    "BNA_KC_Medical_areaHealMaxPatients",
+    2
+] call BIS_fnc_returnConfigEntry;
 
 _currentPatients = [];
 _object setVariable ["BNA_KC_healHandlers", []];

--- a/BNA_KC_Scripts/Data/Functions/Medical/fn_areaSlowHeal.sqf
+++ b/BNA_KC_Scripts/Data/Functions/Medical/fn_areaSlowHeal.sqf
@@ -101,7 +101,11 @@ while {!isNull _object} do
     _unitsToHeal = _currentPatients + _unitsToHeal;
     format ["Patients + units to heal: %1", _unitsToHeal] call BNAKC_fnc_devLog;
 
-    _unitsToHeal = _unitsToHeal select [0, _maxPatients]; // Get only the first x patients
+    if (_maxPatients > 0) then
+    {
+        _unitsToHeal = _unitsToHeal select [0, _maxPatients]; // Get only the first x patients
+    };
+
     format ["Units to heal: %1", _unitsToHeal] call BNAKC_fnc_devLog;
     format ["Actual Units to heal: %1", _unitsToHeal - _currentPatients] call BNAKC_fnc_devLog;
 

--- a/BNA_KC_Scripts/Data/Functions/Medical/fn_areaSlowHeal.sqf
+++ b/BNA_KC_Scripts/Data/Functions/Medical/fn_areaSlowHeal.sqf
@@ -64,10 +64,8 @@ while {!isNull _object} do
     format ["All nearby units: %1", _nearbyUnits] call BNAKC_fnc_devLog;
 
     {
-        // Skip if unit is not hurt
-        if (_x call BNAKC_fnc_isFullyHealed) then { continue; };
-        // Skip if unit is already being healed
-        if (_x in _currentPatients) then { continue; };
+        if (_x call BNAKC_fnc_isFullyHealed) then {continue;}; // Skip if unit is not hurt
+        if (_x in _currentPatients) then {continue;};          // Skip if unit is already being healed
 
         _unitsToHeal pushBack _x;
     } forEach _nearbyUnits;
@@ -76,10 +74,7 @@ while {!isNull _object} do
     format ["Current patients before checks: %1", _currentPatients] call BNAKC_fnc_devLog;
 
     // Remove any patients that have become fully healed
-    _currentPatients = _currentPatients select
-    {
-        !(_x call BNAKC_fnc_isFullyHealed)
-    };
+    _currentPatients = _currentPatients select {!(_x call BNAKC_fnc_isFullyHealed)};
     format ["Current patients that are still hurt: %1", _currentPatients] call BNAKC_fnc_devLog;
     for "_x" from 0 to (count _currentPatients - 1) do
     {
@@ -97,7 +92,7 @@ while {!isNull _object} do
     };
     format ["Current patients after checks: %1", _currentPatients] call BNAKC_fnc_devLog;
 
-    if (_unitsToHeal isEqualTo []) then { "No units to heal, skipping" call BNAKC_fnc_devLog; continue; };
+    if (_unitsToHeal isEqualTo []) then {"No units to heal, skipping" call BNAKC_fnc_devLog; continue;};
 
     // Sort by most injured to least
     _unitsToHeal = [_unitsToHeal] call BNAKC_fnc_sortUnitsByInjuries;

--- a/BNA_KC_Weapons/Grenades/Config.cpp
+++ b/BNA_KC_Weapons/Grenades/Config.cpp
@@ -52,8 +52,10 @@ class CfgMagazines
         ammo = "BNA_KC_Grenade_BactaBomb_Ammo";
 
         BNA_KC_GrenadeType = "BACTA";
-        BNA_KC_GrenadeBacta_Radius = 20;
         BNA_KC_GrenadeBacta_Duration = 20;
+        BNA_KC_Medical_areaHealRadius = 20;
+        BNA_KC_Medical_areaHealRate = 0.5;
+        BNA_KC_Medical_areaHealMaxPatients = -1; // 0 < means no max patients
     };
 };
 


### PR DESCRIPTION
### Description
Cleaned up `fn_areaSlowHeal.sqf`, added ability to specify an unlimited amount of patients (when `_maxPatients` is < 1). Bacta grenades now use area slow heal script, rather than their own system.