### PR TITLE
Bacta Grenade Fixes

### DIFF
--- a/BNA_KC_Scripts/Data/Functions/Medical/fn_areaSlowHeal.sqf
+++ b/BNA_KC_Scripts/Data/Functions/Medical/fn_areaSlowHeal.sqf
@@ -13,8 +13,8 @@
  */
 
 
-params [["_object", objNull, [objNull]]];
-private ["_healRadius", "_healRate", "_maxPatients", "_currentPatients", "_objectName"];
+params [["_object", objNull, [objNull]], ["_healRate", -1, [0]]];
+private ["_healRadius", "_maxPatients", "_currentPatients", "_objectName"];
 
 if (isNull _object) exitWith {};
 
@@ -30,12 +30,16 @@ _healRadius =
     "BNA_KC_Medical_areaHealRadius",
     7
 ] call BIS_fnc_returnConfigEntry;
-_healRate =
-[
-    configFile >> "CfgVehicles" >> typeOf _object,
-    "BNA_KC_Medical_areaHealRate",
-    6
-] call BIS_fnc_returnConfigEntry;
+if (_healRate isEqualTo -1) then
+{
+    // Allows passing a custom heal rate, if none is passed, check the object is CfgVehicles
+    _healRate =
+    [
+        configFile >> "CfgVehicles" >> typeOf _object,
+        "BNA_KC_Medical_areaHealRate",
+        6
+    ] call BIS_fnc_returnConfigEntry;
+};
 _maxPatients =
 [
     configFile >> "CfgVehicles" >> typeOf _object,

--- a/BNA_KC_Scripts/Data/Functions/Weapons/fn_specialGrenadesEH.sqf
+++ b/BNA_KC_Scripts/Data/Functions/Weapons/fn_specialGrenadesEH.sqf
@@ -89,13 +89,20 @@ params ["_eventHandlerType"];
             case "BACTA":
             {
                 private ["_healDuration", "_currentTime", "_endTime"];
-                _projectile call BNAKC_fnc_areaSlowHeal;
                 _healDuration =
                 [
-                    (configFile >> "CfgMagazines" >> _magazine),
+                    configFile >> "CfgMagazines" >> _magazine,
                     "BNA_KC_GrenadeBacta_Duration",
                     5
                 ] call BIS_fnc_returnConfigEntry;
+
+                _healRate =
+                [
+                    configFile >> "CfgMagazines" >> _magazine,
+                    "BNA_KC_Medical_areaHealRate",
+                    5
+                ] call BIS_fnc_returnConfigEntry;
+                [_projectile, _healRate] call BNAKC_fnc_areaSlowHeal;
 
                 _currentTime = time max serverTime;
                 _endTime = _currentTime + _healDuration;


### PR DESCRIPTION
### Changes
- Fixed Bacta Grenades using default heal rate (six seconds)