### PR TITLE
AAT

### DIFF
--- a/BNA_KC_OPFOR/CIS/Config.cpp
+++ b/BNA_KC_OPFOR/CIS/Config.cpp
@@ -256,4 +256,9 @@ class CfgEditorSubcategories
     {
         displayName = "Spec Ops";
     };
+
+    class BNA_KC_SubCat_CIS_Tanks: BNA_KC_SubCat_CIS_Infantry
+    {
+        displayName = "Tanks";
+    };
 };

--- a/BNA_KC_OPFOR/CIS/Config.cpp
+++ b/BNA_KC_OPFOR/CIS/Config.cpp
@@ -241,7 +241,7 @@ class CfgFactionClasses
 
 class CfgEditorSubcategories
 {
-    class BNA_KC_SubCat_CIS_SpecOps
+    class BNA_KC_SubCat_CIS_Infantry
     {
         dlc = "BNA_KC";
         author = "SweMonkey and DartRuffian";
@@ -249,6 +249,11 @@ class CfgEditorSubcategories
         scope = 2;
         scopeCurator = 2;
 
+        displayName = "Infantry";
+    };
+
+    class BNA_KC_SubCat_CIS_SpecOps: BNA_KC_SubCat_CIS_Infantry
+    {
         displayName = "Spec Ops";
     };
 };

--- a/BNA_KC_OPFOR/TechnoUnion/CfgPatches.hpp
+++ b/BNA_KC_OPFOR/TechnoUnion/CfgPatches.hpp
@@ -30,11 +30,14 @@ class CfgPatches
                 // Shadow Mask picture
             "A3_Weapons_F_Ammoboxes",
                 // Base backpack
-            "LFPModels"
+            "LFPModels",
                 // Shadow Mask
+            "BNA_KC_Vehicles_AAT"
+                // AAT
         };
         units[] =
         {
+            // Units
             "BNA_KC_TU_Unit_Base",
             "BNA_KC_TU_Unit_Rifleman",
             "BNA_KC_TU_Unit_AssaultHeavy",
@@ -44,6 +47,7 @@ class CfgPatches
             "BNA_KC_TU_Unit_SL",
             "BNA_KC_TU_Unit_Melee",
 
+            // Backpacks
             "BNA_KC_TU_Backpack",
             "BNA_KC_TU_Backpack_Predef_Rifleman",
             "BNA_KC_TU_Backpack_Heavy",
@@ -53,7 +57,10 @@ class CfgPatches
             "BNA_KC_TU_Backpack_Assault_Predef_Heavy",
             "BNA_KC_TU_Backpack_Assault_Predef_Medium",
             "BNA_KC_TU_Backpack_RTO",
-            "BNA_KC_TU_Backpack_RTO_Predef_SL"
+            "BNA_KC_TU_Backpack_RTO_Predef_SL",
+
+            // Vehicles
+            "BNA_KC_AAT_TU"
         };
         weapons[] =
         {

--- a/BNA_KC_OPFOR/TechnoUnion/CfgVehicles.hpp
+++ b/BNA_KC_OPFOR/TechnoUnion/CfgVehicles.hpp
@@ -1,0 +1,27 @@
+class BNA_KC_AAT_CIS;
+class BNA_KC_AAT_TU: BNA_KC_AAT_CIS
+{
+    faction = "BNA_KC_OPFOR_TU";
+    editorSubcategory = "BNA_KC_SubCat_TU_Tanks";
+
+    crew = "BNA_KC_TU_Unit_Rifleman";
+    typicalCargo[] = {"BNA_KC_TU_Unit_Rifleman"};
+
+    hiddenSelectionsTextures[] = {"\3AS\3AS_AAT\data\Tan_AAT_CO.paa"};
+    editorPreview = "\3as\3AS_AAT\images\3AS_AAT_tan.jpg";
+
+    textureList[] =
+    {
+        "CIS", 0,
+        "TradeFederation", 1,
+        "Green", 0,
+        "Red", 0,
+        "Desert", 0,
+        "Geonosis", 0,
+        "Woodland", 0,
+        "Tropical", 0,
+        "Arid", 0,
+        "Winter", 0,
+        "Aqua", 0
+    };
+};

--- a/BNA_KC_OPFOR/TechnoUnion/Config.cpp
+++ b/BNA_KC_OPFOR/TechnoUnion/Config.cpp
@@ -324,6 +324,11 @@ class CfgVehicles
             TRANSMAG_XX(JMSLLTE_thermalimploder_HandGrenade, 5)
         };
     };
+
+    // ┌───────────────────┐
+    // │      Vehicles     │
+    // └───────────────────┘
+    #include "CfgVehicles.hpp"
 };
 
 
@@ -353,6 +358,11 @@ class CfgEditorSubcategories
         scopeCurator = 2;
 
         displayName = "Infantry";
+    };
+
+    class BNA_KC_SubCat_TU_Tanks: BNA_KC_SubCat_TU_Infantry
+    {
+        displayName = "Tanks";
     };
 };
 

--- a/BNA_KC_Vehicles/Armored/AAT/CfgPatches.hpp
+++ b/BNA_KC_Vehicles/Armored/AAT/CfgPatches.hpp
@@ -18,7 +18,7 @@ class CfgPatches
         };
         units[] =
         {
-            "BNA_KC_AAT"
+            "BNA_KC_AAT_CIS"
         };
         weapons[] = {};
     };

--- a/BNA_KC_Vehicles/Armored/AAT/CfgPatches.hpp
+++ b/BNA_KC_Vehicles/Armored/AAT/CfgPatches.hpp
@@ -1,0 +1,22 @@
+class CfgPatches
+{
+    class BNA_KC_Vehicles_AAT
+    {
+        addonRootClass= "BNA_KC_Vehicles";
+        author = "SweMonkey and DartRuffian";
+        requiredVersion = 0.1;
+        requiredAddons[] =
+        {
+            "BNA_KC_Vehicles",
+                // Core Config
+            "3AS_AAT",
+                // AAT
+            "BNA_KC_OPFOR_CIS",
+                // Faction / Subcategory
+            "JLTS_characters_DroidArmor",
+                // Crew Unit
+        };
+        units[] = {};
+        weapons[] = {};
+    };
+};

--- a/BNA_KC_Vehicles/Armored/AAT/CfgPatches.hpp
+++ b/BNA_KC_Vehicles/Armored/AAT/CfgPatches.hpp
@@ -16,7 +16,10 @@ class CfgPatches
             "JLTS_characters_DroidArmor",
                 // Crew Unit
         };
-        units[] = {};
+        units[] =
+        {
+            "BNA_KC_AAT"
+        };
         weapons[] = {};
     };
 };

--- a/BNA_KC_Vehicles/Armored/AAT/Config.cpp
+++ b/BNA_KC_Vehicles/Armored/AAT/Config.cpp
@@ -39,7 +39,7 @@ class CfgVehicles
             };
         };
     };
-    class BNA_KC_AAT: 3AS_AAT
+    class BNA_KC_AAT_CIS: 3AS_AAT
     {
         // Mod Info
         dlc = "BNA_KC";

--- a/BNA_KC_Vehicles/Armored/AAT/Config.cpp
+++ b/BNA_KC_Vehicles/Armored/AAT/Config.cpp
@@ -9,13 +9,34 @@ class CfgVehicles
     {
         class Turrets;
     };
-    class 3AS_CIS_AAT_base_F: 3AS_AAT_base_F {};
-    class 3AS_CIS_AAT_F: 3AS_CIS_AAT_base_F {};
-    class 3AS_AAT: 3AS_CIS_AAT_F
+    class 3AS_CIS_AAT_base_F: 3AS_AAT_base_F
     {
         class Turrets: Turrets
         {
             class MainTurret;
+        };
+    };
+    class 3AS_CIS_AAT_F: 3AS_CIS_AAT_base_F
+    {
+        class Turrets: Turrets
+        {
+            class MainTurret: MainTurret
+            {
+                class Turrets;
+            };
+        };
+    };
+    class 3AS_AAT: 3AS_CIS_AAT_F
+    {
+        class Turrets: Turrets
+        {
+            class MainTurret: MainTurret
+            {
+                class Turrets: Turrets
+                {
+                    class CommanderOptics;
+                };
+            };
         };
     };
     class BNA_KC_AAT: 3AS_AAT
@@ -48,6 +69,28 @@ class CfgVehicles
                     "3AS_24Rnd_AAT_AP",
                     "3AS_24Rnd_AAT_AP",
                     "SmokeLauncherMag"
+                };
+
+                class Turrets: Turrets
+                {
+                    class CommanderOptics: CommanderOptics
+                    {
+                        weapons[] = {"3AS_AAT_Repeater", "SmokeLauncher"};
+                        magazines[] =
+                        {
+                            "3AS_500Rnd_ATT_RedPlasma",
+                            "3AS_500Rnd_ATT_RedPlasma",
+                            "3AS_500Rnd_ATT_RedPlasma",
+                            "3AS_500Rnd_ATT_RedPlasma",
+                            "3AS_500Rnd_ATT_RedPlasma",
+                            "3AS_500Rnd_ATT_RedPlasma",
+                            "3AS_500Rnd_ATT_RedPlasma",
+                            "3AS_500Rnd_ATT_RedPlasma",
+                            "3AS_500Rnd_ATT_RedPlasma",
+                            "3AS_500Rnd_ATT_RedPlasma",
+                            "SmokeLauncherMag"
+                        };
+                    };
                 };
             };
         };

--- a/BNA_KC_Vehicles/Armored/AAT/Config.cpp
+++ b/BNA_KC_Vehicles/Armored/AAT/Config.cpp
@@ -1,0 +1,28 @@
+#include "CfgPatches.hpp"
+#include "..\..\Common\Macros.hpp"
+
+
+class CfgVehicles
+{
+    class 3AS_AAT;
+    class BNA_KC_AAT: 3AS_AAT
+    {
+        // Mod Info
+        dlc = "BNA_KC";
+        author = "SweMonkey and DartRuffian";
+
+        // Scope
+        scope = 2;
+        scopeCurator = 2;
+
+        // Editor Attributes
+        faction = "BNA_KC_OPFOR_CIS";
+        editorSubcategory = "BNA_KC_SubCat_CIS_Tanks";
+
+        displayName = "AAT";
+        crew = "JLTS_Droid_B1_Crew";
+        typicalCargo[] = {"JLTS_Droid_B1_Crew"};
+
+        hiddenSelectionsTextures[] = {"\3AS\3AS_AAT\data\CIS_AAT_CO.paa"};
+    };
+};

--- a/BNA_KC_Vehicles/Armored/AAT/Config.cpp
+++ b/BNA_KC_Vehicles/Armored/AAT/Config.cpp
@@ -85,49 +85,51 @@ class CfgVehicles
             class TradeFederation: CIS
             {
                 displayName = "Trade Federation";
+                factions[] = {"BNA_KC_OPFOR_TU"};
                 textures[] = {"\3AS\3AS_AAT\data\Tan_AAT_CO.paa"};
             };
             class Green: CIS
             {
                 displayName = "Green";
+                factions[] = {"BNA_KC_OPFOR_CIS", "BNA_KC_OPFOR_TU"};
                 textures[] = {"\3AS\3AS_AAT\data\Green_AAT_CO.paa"};
             };
-            class Red: CIS
+            class Red: Green
             {
                 displayName = "Red";
                 textures[] = {"\3AS\3AS_AAT\data\Red_AAT_CO.paa"};
             };
-            class Desert
+            class Desert: Green
             {
                 displayName = "Camo - Desert";
                 textures[] = {"\3AS\3AS_AAT\data\Desert_AAT_CO.paa"};
             };
-            class Geonosis
+            class Geonosis: Green
             {
                 displayName = "Camo - Geonosis";
                 textures[] = {"\3AS\3AS_AAT\data\Geonosis_AAT_CO.paa"};
             };
-            class Woodland
+            class Woodland: Green
             {
                 displayName = "Camo - Woodland";
                 textures[] = {"\3AS\3AS_AAT\data\Woodland_AAT_CO.paa"};
             };
-            class Tropical
+            class Tropical: Green
             {
                 displayName = "Camo - Tropical";
                 textures[] = {"\3AS\3AS_AAT\data\Tropical_AAT_CO.paa"};
             };
-            class Arid
+            class Arid: Green
             {
                 displayName = "Camo - Arid";
                 textures[] = {"\3AS\3AS_AAT\data\Arid_AAT_CO.paa"};
             };
-            class Winter
+            class Winter: Green
             {
                 displayName = "Camo - Winter";
                 textures[] = {"\3AS\3AS_AAT\data\Winter_AAT_CO.paa"};
             };
-            class Aqua
+            class Aqua: Green
             {
                 displayName = "Camo - Aqua";
                 textures[] = {"\3AS\3AS_AAT\data\Aqua_AAT_CO.paa"};

--- a/BNA_KC_Vehicles/Armored/AAT/Config.cpp
+++ b/BNA_KC_Vehicles/Armored/AAT/Config.cpp
@@ -59,6 +59,81 @@ class CfgVehicles
 
         hiddenSelectionsTextures[] = {"\3AS\3AS_AAT\data\CIS_AAT_CO.paa"};
 
+        textureList[] =
+        {
+            "CIS", 1,
+            "TradeFederation", 0,
+            "Green", 0,
+            "Red", 0,
+            "Desert", 0,
+            "Geonosis", 0,
+            "Woodland", 0,
+            "Tropical", 0,
+            "Arid", 0,
+            "Winter", 0,
+            "Aqua", 0
+        };
+        class TextureSources
+        {
+            class CIS
+            {
+                displayName = "CIS";
+                author = "$STR_3AS_Studio";
+                factions[] = {"BNA_KC_OPFOR_CIS"};
+                textures[] = {"\3AS\3AS_AAT\data\CIS_AAT_CO.paa"};
+            };
+            class TradeFederation: CIS
+            {
+                displayName = "Trade Federation";
+                textures[] = {"\3AS\3AS_AAT\data\Tan_AAT_CO.paa"};
+            };
+            class Green: CIS
+            {
+                displayName = "Green";
+                textures[] = {"\3AS\3AS_AAT\data\Green_AAT_CO.paa"};
+            };
+            class Red: CIS
+            {
+                displayName = "Red";
+                textures[] = {"\3AS\3AS_AAT\data\Red_AAT_CO.paa"};
+            };
+            class Desert
+            {
+                displayName = "Camo - Desert";
+                textures[] = {"\3AS\3AS_AAT\data\Desert_AAT_CO.paa"};
+            };
+            class Geonosis
+            {
+                displayName = "Camo - Geonosis";
+                textures[] = {"\3AS\3AS_AAT\data\Geonosis_AAT_CO.paa"};
+            };
+            class Woodland
+            {
+                displayName = "Camo - Woodland";
+                textures[] = {"\3AS\3AS_AAT\data\Woodland_AAT_CO.paa"};
+            };
+            class Tropical
+            {
+                displayName = "Camo - Tropical";
+                textures[] = {"\3AS\3AS_AAT\data\Tropical_AAT_CO.paa"};
+            };
+            class Arid
+            {
+                displayName = "Camo - Arid";
+                textures[] = {"\3AS\3AS_AAT\data\Arid_AAT_CO.paa"};
+            };
+            class Winter
+            {
+                displayName = "Camo - Winter";
+                textures[] = {"\3AS\3AS_AAT\data\Winter_AAT_CO.paa"};
+            };
+            class Aqua
+            {
+                displayName = "Camo - Aqua";
+                textures[] = {"\3AS\3AS_AAT\data\Aqua_AAT_CO.paa"};
+            };
+        };
+
         class Turrets: Turrets
         {
             class MainTurret: MainTurret

--- a/BNA_KC_Vehicles/Armored/AAT/Config.cpp
+++ b/BNA_KC_Vehicles/Armored/AAT/Config.cpp
@@ -51,5 +51,24 @@ class CfgVehicles
                 };
             };
         };
+
+        class AnimationSources
+        {
+            class recoil_source
+            {
+                source = "reload";
+                weapon = "3AS_AATCannon";
+            };
+            class muzzle_rot_cannon
+            {
+                source = "ammorandom";
+                weapon = "3AS_AAT_Repeater";
+            };
+            class muzzle_rot_coax
+            {
+                source = "ammorandom";
+                weapon = "3AS_AAT_Repeater";
+            };
+        };
     };
 };

--- a/BNA_KC_Vehicles/Armored/AAT/Config.cpp
+++ b/BNA_KC_Vehicles/Armored/AAT/Config.cpp
@@ -4,7 +4,20 @@
 
 class CfgVehicles
 {
-    class 3AS_AAT;
+    class Tank_F;
+    class 3AS_AAT_base_F: Tank_F
+    {
+        class Turrets;
+    };
+    class 3AS_CIS_AAT_base_F: 3AS_AAT_base_F {};
+    class 3AS_CIS_AAT_F: 3AS_CIS_AAT_base_F {};
+    class 3AS_AAT: 3AS_CIS_AAT_F
+    {
+        class Turrets: Turrets
+        {
+            class MainTurret;
+        };
+    };
     class BNA_KC_AAT: 3AS_AAT
     {
         // Mod Info
@@ -24,5 +37,19 @@ class CfgVehicles
         typicalCargo[] = {"JLTS_Droid_B1_Crew"};
 
         hiddenSelectionsTextures[] = {"\3AS\3AS_AAT\data\CIS_AAT_CO.paa"};
+
+        class Turrets: Turrets
+        {
+            class MainTurret: MainTurret
+            {
+                weapons[] = {"3AS_AATCannon", "SmokeLauncher"};
+                magazines[] =
+                {
+                    "3AS_24Rnd_AAT_AP",
+                    "3AS_24Rnd_AAT_AP",
+                    "SmokeLauncherMag"
+                };
+            };
+        };
     };
 };


### PR DESCRIPTION
### Description
CIS and Techno Union variants of the AAT.

### Changes
- Added AAT
  - All vehicle texture options from 3AS
  - CIS (blue) exclusive to CIS AAT, Techno Union (tan) exclusive to Techno Union AAT
- Added subcategory for Techno Union Tanks
- Renamed CIS classes
  - `BNA_KC_OPFOR_...` -> `BNA_KC_CIS_...`