### PR TITLE
EPF Officers

### DIFF
--- a/BNA_KC_Core/CfgEditorSubcategories.hpp
+++ b/BNA_KC_Core/CfgEditorSubcategories.hpp
@@ -17,6 +17,10 @@ class CfgEditorSubcategories
     {
         displayName = "Special Forces";
     };
+    class BNA_KC_SubCat_Special: BNA_KC_SubCat_Infantry
+    {
+        displayName = "Special"; // Used for things like faction officers
+    };
 
     // Ground Vehicles
     class BNA_KC_SubCat_Tanks: BNA_KC_SubCat_Infantry

--- a/BNA_KC_Core/Macros.hpp
+++ b/BNA_KC_Core/Macros.hpp
@@ -47,3 +47,8 @@
 // Armor Macros
 #define HEARING_PROTECTION_CREW ace_hearing_lowerVolume = 0.6; \
 ace_hearing_protection = 0.85;
+
+#define OPFOR 0
+#define BLUFOR 1
+#define INDEP 2
+#define CIVILIAN 3

--- a/BNA_KC_INDEP/Config.cpp
+++ b/BNA_KC_INDEP/Config.cpp
@@ -43,8 +43,8 @@ class CfgVehicles
         displayName = "INDEP Unit Base";
         uniformClass = "BNA_KC_INDEP_Uniform_Base";
 
-        weapons[] = {};
-        respawnWeapons[] = {};
+        weapons[] = {"Throw", "Put"};
+        respawnWeapons[] = {"Throw", "Put"};
         magazines[] = {};
         respawnMagazines[] = {};
         items[] = {};

--- a/BNA_KC_INDEP/Config.cpp
+++ b/BNA_KC_INDEP/Config.cpp
@@ -1,4 +1,5 @@
 #include "CfgPatches.hpp"
+#include "Macros.hpp"
 
 
 class CfgWeapons
@@ -42,6 +43,8 @@ class CfgVehicles
     {
         displayName = "INDEP Unit Base";
         uniformClass = "BNA_KC_INDEP_Uniform_Base";
+
+        modelSides[] = {INDEP};
 
         weapons[] = {"Throw", "Put"};
         respawnWeapons[] = {"Throw", "Put"};

--- a/BNA_KC_INDEP/Config.cpp
+++ b/BNA_KC_INDEP/Config.cpp
@@ -49,6 +49,8 @@ class CfgVehicles
         respawnMagazines[] = {};
         items[] = {};
         respawnItems[] = {};
+        linkedItems[] = {};
+        respawnLinkedItems[] = {};
         backpack = "";
     };
 

--- a/BNA_KC_OPFOR/Config.cpp
+++ b/BNA_KC_OPFOR/Config.cpp
@@ -44,8 +44,8 @@ class CfgVehicles
         displayName = "OPFOR Unit Base";
         uniformClass = "BNA_KC_OPFOR_Uniform_Base";
 
-        weapons[] = {};
-        respawnWeapons[] = {};
+        weapons[] = {"Throw", "Put"};
+        respawnWeapons[] = {"Throw", "Put"};
         magazines[] = {};
         respawnMagazines[] = {};
         items[] = {};

--- a/BNA_KC_OPFOR/Config.cpp
+++ b/BNA_KC_OPFOR/Config.cpp
@@ -50,6 +50,8 @@ class CfgVehicles
         respawnMagazines[] = {};
         items[] = {};
         respawnItems[] = {};
+        linkedItems[] = {};
+        respawnLinkedItems[] = {};
         backpack = "";
     };
 

--- a/BNA_KC_OPFOR/Config.cpp
+++ b/BNA_KC_OPFOR/Config.cpp
@@ -1,4 +1,5 @@
 #include "CfgPatches.hpp"
+#include "Macros.hpp"
 
 
 class CfgWeapons
@@ -43,6 +44,8 @@ class CfgVehicles
     {
         displayName = "OPFOR Unit Base";
         uniformClass = "BNA_KC_OPFOR_Uniform_Base";
+
+        modelSides[] = {OPFOR};
 
         weapons[] = {"Throw", "Put"};
         respawnWeapons[] = {"Throw", "Put"};

--- a/BNA_KC_OPFOR/EPF/CfgPatches.hpp
+++ b/BNA_KC_OPFOR/EPF/CfgPatches.hpp
@@ -23,14 +23,6 @@ class CfgPatches
                 // Officer Uniform
             "A3_Characters_F_Heads",
                 // Persian Head 1
-            "BNA_KC_Weapons_E5",
-                // E-5
-            "BNA_KC_Weapons_E5C",
-                // E-5C
-            "BNA_KC_Weapons_E60R",
-                // E-60R
-            "OPTRE_FC_Weapons_PlasmaGrenade",
-                // Plasma Grenade
             "BNA_KC_Vehicles",
                 // Subcategories
             "BNA_KC_Vehicles_AAT",

--- a/BNA_KC_OPFOR/EPF/CfgPatches.hpp
+++ b/BNA_KC_OPFOR/EPF/CfgPatches.hpp
@@ -107,10 +107,12 @@ class CfgPatches
             "BNA_KC_EPF_Helmet_Visor_Goggles",
             "BNA_KC_EPF_Helmet_Heavy",
             "BNA_KC_EPF_Helmet_Presidente",
+            "BNA_KC_EPF_Helmet_General",
 
             // Uniforms
             "BNA_KC_EPF_Uniform",
             "BNA_KC_EPF_Uniform_Presidente",
+            "BNA_KC_EPF_Uniform_General",
 
             // Vests
             "BNA_KC_EPF_Vest",

--- a/BNA_KC_OPFOR/EPF/CfgPatches.hpp
+++ b/BNA_KC_OPFOR/EPF/CfgPatches.hpp
@@ -118,7 +118,8 @@ class CfgPatches
             "BNA_KC_EPF_Vest",
             "BNA_KC_EPF_Vest_Medium",
             "BNA_KC_EPF_Vest_AssaultMedium",
-            "BNA_KC_EPF_Vest_AssaultHeavy"
+            "BNA_KC_EPF_Vest_AssaultHeavy",
+            "BNA_KC_EPF_Vest_General"
         };
 
         skipWhenMissingDependencies = 1;

--- a/BNA_KC_OPFOR/EPF/CfgPatches.hpp
+++ b/BNA_KC_OPFOR/EPF/CfgPatches.hpp
@@ -62,6 +62,7 @@ class CfgPatches
             "BNA_KC_EPF_Unit_AssaultMedium",
             "BNA_KC_EPF_Unit_SL",
             "BNA_KC_EPF_Unit_Melee",
+            "BNA_KC_EPF_Unit_Presidente",
 
             // Backpacks
             "BNA_KC_EPF_Backpack",

--- a/BNA_KC_OPFOR/EPF/CfgPatches.hpp
+++ b/BNA_KC_OPFOR/EPF/CfgPatches.hpp
@@ -21,6 +21,8 @@ class CfgPatches
                 // Officer Cap
             "A3_Characters_F_AoW",
                 // Officer Uniform
+            "A3_Characters_F_Heads",
+                // Persian Head 1
             "BNA_KC_Weapons_E5",
                 // E-5
             "BNA_KC_Weapons_E5C",

--- a/BNA_KC_OPFOR/EPF/CfgPatches.hpp
+++ b/BNA_KC_OPFOR/EPF/CfgPatches.hpp
@@ -17,6 +17,10 @@ class CfgPatches
                 // Uniform textures
                 // Vests
                 // Backpacks
+            "A3_Characters_F_AoW_Headgear",
+                // Officer Cap
+            "A3_Characters_F_AoW",
+                // Officer Uniform
             "BNA_KC_Weapons_E5",
                 // E-5
             "BNA_KC_Weapons_E5C",
@@ -99,9 +103,11 @@ class CfgPatches
             "BNA_KC_EPF_Helmet_Visor",
             "BNA_KC_EPF_Helmet_Visor_Goggles",
             "BNA_KC_EPF_Helmet_Heavy",
+            "BNA_KC_EPF_Helmet_Presidente",
 
             // Uniforms
             "BNA_KC_EPF_Uniform",
+            "BNA_KC_EPF_Uniform_Presidente",
 
             // Vests
             "BNA_KC_EPF_Vest",

--- a/BNA_KC_OPFOR/EPF/CfgUnits.hpp
+++ b/BNA_KC_OPFOR/EPF/CfgUnits.hpp
@@ -152,16 +152,20 @@ class BNA_KC_EPF_Unit_General: BNA_KC_EPF_Unit_Presidente
     respawnWeapons[] = {"BNA_KC_DC17M", "BNA_KC_DC15SA", "Throw", "Put"};
     magazines[] =
     {
-        "Aux12thFleet_Mag_60Rnd_DC17M",
-        "Aux12thFleet_Mag_7Rnd_DC15SA"
+        ITEM_10("Aux12thFleet_Mag_60Rnd_DC17M"),
+        ITEM_4("Aux12thFleet_Mag_7Rnd_DC15SA"),
+        ITEM_2("SmokeShell"),
+        ITEM_2("SC_IG3")
     };
     respawnMagazines[] =
     {
-        "Aux12thFleet_Mag_60Rnd_DC17M",
-        "Aux12thFleet_Mag_7Rnd_DC15SA"
+        ITEM_10("Aux12thFleet_Mag_60Rnd_DC17M"),
+        ITEM_4("Aux12thFleet_Mag_7Rnd_DC15SA"),
+        ITEM_2("SmokeShell"),
+        ITEM_2("SC_IG3")
     };
-    items[] = {};
-    respawnItems[] = {};
+    items[] = {"FirstAidKit"};
+    respawnItems[] = {"FirstAidKit"};
     linkedItems[] = {"BNA_KC_EPF_Helmet_General", "BNA_KC_EPF_Vest_General", "SC_MDFCape", LINKED_ITEMS_RADIO};
     respawnLinkedItems[] = {"BNA_KC_EPF_Helmet_General", "BNA_KC_EPF_Vest_General", "SC_MDFCape", LINKED_ITEMS_RADIO};
     backpack = "";

--- a/BNA_KC_OPFOR/EPF/CfgUnits.hpp
+++ b/BNA_KC_OPFOR/EPF/CfgUnits.hpp
@@ -148,6 +148,8 @@ class BNA_KC_EPF_Unit_General: BNA_KC_EPF_Unit_Presidente
     hiddenSelectionsTextures[] = {"\sc_equipment\data\combat_uniform\cu_black_co.paa"};
     hiddenSelectionsMaterials[] = {"\a3\characters_f_beta\indep\data\ia_soldier_01_clothing.rvmat"};
 
+    identityTypes[] = {"ElPresidente"};
+
     weapons[] = {"BNA_KC_DC17M", "BNA_KC_DC15SA", "Throw", "Put"};
     respawnWeapons[] = {"BNA_KC_DC17M", "BNA_KC_DC15SA", "Throw", "Put"};
     magazines[] =
@@ -169,4 +171,9 @@ class BNA_KC_EPF_Unit_General: BNA_KC_EPF_Unit_Presidente
     linkedItems[] = {"BNA_KC_EPF_Helmet_General", "BNA_KC_EPF_Vest_General", "SC_MDFCape", LINKED_ITEMS_RADIO};
     respawnLinkedItems[] = {"BNA_KC_EPF_Helmet_General", "BNA_KC_EPF_Vest_General", "SC_MDFCape", LINKED_ITEMS_RADIO};
     backpack = "";
+
+    class EventHandlers: EventHandlers
+    {
+        init = "(_this select 0) setIdentity 'ElGeneral'";
+    };
 };

--- a/BNA_KC_OPFOR/EPF/CfgUnits.hpp
+++ b/BNA_KC_OPFOR/EPF/CfgUnits.hpp
@@ -9,6 +9,8 @@ class BNA_KC_EPF_Unit_Rifleman: BNA_KC_TU_Unit_Rifleman
     linkedItems[] = {"BNA_KC_EPF_Helmet", "BNA_KC_EPF_Vest", LINKED_ITEMS_RADIO};
     respawnLinkedItems[] = {"BNA_KC_EPF_Helmet", "BNA_KC_EPF_Vest", LINKED_ITEMS_RADIO};
     backpack = "BNA_KC_EPF_Backpack_Predef_Rifleman";
+
+    class EventHandlers;
 };
 
 class BNA_KC_EPF_Unit_Rifleman_Shield: BNA_KC_EPF_Unit_Rifleman
@@ -118,6 +120,8 @@ class BNA_KC_EPF_Unit_Presidente: BNA_KC_EPF_Unit_Rifleman
         "\a3\characters_f_aow\uniforms\data\Ribbon_01_US_CO.paa"
     };
 
+    identityTypes[] = {"ElPresidente", "G_NATO_default"};
+
     weapons[] = {};
     respawnWeapons[] = {};
     magazines[] = {};
@@ -127,4 +131,9 @@ class BNA_KC_EPF_Unit_Presidente: BNA_KC_EPF_Unit_Rifleman
     linkedItems[] = {"BNA_KC_EPF_Helmet_Presidente", "OPTRE_Glasses_Cigar", LINKED_ITEMS_RADIO};
     respawnLinkedItems[] = {"BNA_KC_EPF_Helmet_Presidente", "OPTRE_Glasses_Cigar", LINKED_ITEMS_RADIO};
     backpack = "";
+
+    class EventHandlers: EventHandlers
+    {
+        init = "(_this select 0) setIdentity 'ElPresidente'";
+    };
 };

--- a/BNA_KC_OPFOR/EPF/CfgUnits.hpp
+++ b/BNA_KC_OPFOR/EPF/CfgUnits.hpp
@@ -120,7 +120,7 @@ class BNA_KC_EPF_Unit_Presidente: BNA_KC_EPF_Unit_Rifleman
         "\a3\characters_f_aow\uniforms\data\Ribbon_01_US_CO.paa"
     };
 
-    identityTypes[] = {"ElPresidente", "G_NATO_default"};
+    identityTypes[] = {"ElPresidente"};
 
     weapons[] = {};
     respawnWeapons[] = {};

--- a/BNA_KC_OPFOR/EPF/CfgUnits.hpp
+++ b/BNA_KC_OPFOR/EPF/CfgUnits.hpp
@@ -98,3 +98,33 @@ class BNA_KC_EPF_Unit_Melee: BNA_KC_TU_Unit_Melee
     respawnLinkedItems[] = {"BNA_KC_EPF_Helmet_Visor", "BNA_KC_EPF_Vest", LINKED_ITEMS_RADIO};
     backpack = "BNA_KC_EPF_Backpack_Heavy";
 };
+
+class BNA_KC_EPF_Unit_Presidente: BNA_KC_EPF_Unit_Rifleman
+{
+    // Editor Properties
+    editorSubcategory = "BNA_KC_SubCat_Special";
+
+    displayName = "El Presidente"
+    uniformClass = "BNA_KC_EPF_Uniform_Presidente";
+
+    model = "\a3\Characters_F_AoW\Uniforms\ParadeUniform_01_F";
+    hiddenSelections[] = {"camo1", "camo2", "camo3", "ribbon", "nametag"};
+    hiddenSelectionsMaterials[] = {"", "", "\a3\Characters_F_AoW\Uniforms\Data\ParadeUniform_Decorated_01_US.rvmat"};
+    hiddenSelectionsTextures[] =
+    {
+        "\a3\Characters_F_AoW\Uniforms\Data\ParadeUniform_01_US_CO.paa",
+        "\a3\Characters_F_AoW\Uniforms\Data\ParadeUniform_01_US_CO.paa",
+        "\a3\characters_f_aow\uniforms\data\ParadeUniform_Decorated_01_US_CO.paa",
+        "\a3\characters_f_aow\uniforms\data\Ribbon_01_US_CO.paa"
+    };
+
+    weapons[] = {};
+    respawnWeapons[] = {};
+    magazines[] = {};
+    respawnMagazines[] = {};
+    items[] = {};
+    respawnItems[] = {};
+    linkedItems[] = {"BNA_KC_EPF_Helmet_Presidente", "OPTRE_Glasses_Cigar", LINKED_ITEMS_RADIO};
+    respawnLinkedItems[] = {"BNA_KC_EPF_Helmet_Presidente", "OPTRE_Glasses_Cigar", LINKED_ITEMS_RADIO};
+    backpack = "";
+};

--- a/BNA_KC_OPFOR/EPF/CfgUnits.hpp
+++ b/BNA_KC_OPFOR/EPF/CfgUnits.hpp
@@ -122,8 +122,8 @@ class BNA_KC_EPF_Unit_Presidente: BNA_KC_EPF_Unit_Rifleman
 
     identityTypes[] = {"ElPresidente"};
 
-    weapons[] = {};
-    respawnWeapons[] = {};
+    weapons[] = {"Throw", "Put"};
+    respawnWeapons[] = {"Throw", "Put"};
     magazines[] = {};
     respawnMagazines[] = {};
     items[] = {};
@@ -148,8 +148,8 @@ class BNA_KC_EPF_Unit_General: BNA_KC_EPF_Unit_Presidente
     hiddenSelectionsTextures[] = {"\sc_equipment\data\combat_uniform\cu_black_co.paa"};
     hiddenSelectionsMaterials[] = {"\a3\characters_f_beta\indep\data\ia_soldier_01_clothing.rvmat"};
 
-    weapons[] = {};
-    respawnWeapons[] = {};
+    weapons[] = {"Throw", "Put"};
+    respawnWeapons[] = {"Throw", "Put"};
     magazines[] = {};
     respawnMagazines[] = {};
     items[] = {};

--- a/BNA_KC_OPFOR/EPF/CfgUnits.hpp
+++ b/BNA_KC_OPFOR/EPF/CfgUnits.hpp
@@ -137,3 +137,24 @@ class BNA_KC_EPF_Unit_Presidente: BNA_KC_EPF_Unit_Rifleman
         init = "(_this select 0) setIdentity 'ElPresidente'";
     };
 };
+
+class BNA_KC_EPF_Unit_General: BNA_KC_EPF_Unit_Presidente
+{
+    displayName = "El General"
+    uniformClass = "BNA_KC_EPF_Uniform_General";
+
+    model = "\A3\Characters_F_Exp\Gendarmerie\B_GEN_Commander_F.p3d";
+    hiddenSelections[] = {"camo", "insignia"};
+    hiddenSelectionsTextures[] = {"\sc_equipment\data\combat_uniform\cu_black_co.paa"};
+    hiddenSelectionsMaterials[] = {"\a3\characters_f_beta\indep\data\ia_soldier_01_clothing.rvmat"};
+
+    weapons[] = {};
+    respawnWeapons[] = {};
+    magazines[] = {};
+    respawnMagazines[] = {};
+    items[] = {};
+    respawnItems[] = {};
+    linkedItems[] = {"BNA_KC_EPF_Helmet_General", "SC_MDFCape", LINKED_ITEMS_RADIO};
+    respawnLinkedItems[] = {"BNA_KC_EPF_Helmet_General", "SC_MDFCape", LINKED_ITEMS_RADIO};
+    backpack = "";
+};

--- a/BNA_KC_OPFOR/EPF/CfgUnits.hpp
+++ b/BNA_KC_OPFOR/EPF/CfgUnits.hpp
@@ -162,7 +162,7 @@ class BNA_KC_EPF_Unit_General: BNA_KC_EPF_Unit_Presidente
     };
     items[] = {};
     respawnItems[] = {};
-    linkedItems[] = {"BNA_KC_EPF_Helmet_General", "SC_MDFCape", LINKED_ITEMS_RADIO};
-    respawnLinkedItems[] = {"BNA_KC_EPF_Helmet_General", "SC_MDFCape", LINKED_ITEMS_RADIO};
+    linkedItems[] = {"BNA_KC_EPF_Helmet_General", "BNA_KC_EPF_Vest_General", "SC_MDFCape", LINKED_ITEMS_RADIO};
+    respawnLinkedItems[] = {"BNA_KC_EPF_Helmet_General", "BNA_KC_EPF_Vest_General", "SC_MDFCape", LINKED_ITEMS_RADIO};
     backpack = "";
 };

--- a/BNA_KC_OPFOR/EPF/CfgUnits.hpp
+++ b/BNA_KC_OPFOR/EPF/CfgUnits.hpp
@@ -111,7 +111,6 @@ class BNA_KC_EPF_Unit_Presidente: BNA_KC_EPF_Unit_Rifleman
 
     model = "\a3\Characters_F_AoW\Uniforms\ParadeUniform_01_F";
     hiddenSelections[] = {"camo1", "camo2", "camo3", "ribbon", "nametag"};
-    hiddenSelectionsMaterials[] = {"", "", "\a3\Characters_F_AoW\Uniforms\Data\ParadeUniform_Decorated_01_US.rvmat"};
     hiddenSelectionsTextures[] =
     {
         "\a3\Characters_F_AoW\Uniforms\Data\ParadeUniform_01_US_CO.paa",
@@ -119,6 +118,7 @@ class BNA_KC_EPF_Unit_Presidente: BNA_KC_EPF_Unit_Rifleman
         "\a3\characters_f_aow\uniforms\data\ParadeUniform_Decorated_01_US_CO.paa",
         "\a3\characters_f_aow\uniforms\data\Ribbon_01_US_CO.paa"
     };
+    hiddenSelectionsMaterials[] = {"", "", "\a3\Characters_F_AoW\Uniforms\Data\ParadeUniform_Decorated_01_US.rvmat"};
 
     identityTypes[] = {"ElPresidente"};
 

--- a/BNA_KC_OPFOR/EPF/CfgUnits.hpp
+++ b/BNA_KC_OPFOR/EPF/CfgUnits.hpp
@@ -148,10 +148,18 @@ class BNA_KC_EPF_Unit_General: BNA_KC_EPF_Unit_Presidente
     hiddenSelectionsTextures[] = {"\sc_equipment\data\combat_uniform\cu_black_co.paa"};
     hiddenSelectionsMaterials[] = {"\a3\characters_f_beta\indep\data\ia_soldier_01_clothing.rvmat"};
 
-    weapons[] = {"Throw", "Put"};
-    respawnWeapons[] = {"Throw", "Put"};
-    magazines[] = {};
-    respawnMagazines[] = {};
+    weapons[] = {"BNA_KC_DC17M", "BNA_KC_DC15SA", "Throw", "Put"};
+    respawnWeapons[] = {"BNA_KC_DC17M", "BNA_KC_DC15SA", "Throw", "Put"};
+    magazines[] =
+    {
+        "Aux12thFleet_Mag_60Rnd_DC17M",
+        "Aux12thFleet_Mag_7Rnd_DC15SA"
+    };
+    respawnMagazines[] =
+    {
+        "Aux12thFleet_Mag_60Rnd_DC17M",
+        "Aux12thFleet_Mag_7Rnd_DC15SA"
+    };
     items[] = {};
     respawnItems[] = {};
     linkedItems[] = {"BNA_KC_EPF_Helmet_General", "SC_MDFCape", LINKED_ITEMS_RADIO};

--- a/BNA_KC_OPFOR/EPF/Config.cpp
+++ b/BNA_KC_OPFOR/EPF/Config.cpp
@@ -83,7 +83,7 @@ class CfgWeapons
 
     class BNA_KC_EPF_Uniform_Presidente: BNA_KC_EPF_Uniform
     {
-        displayName = "[EPF] El Preidente Uniform";
+        displayName = "[EPF] El Presidente Uniform";
         class ItemInfo: ItemInfo
         {
             uniformClass = "BNA_KC_EPF_Unit_Presidente";

--- a/BNA_KC_OPFOR/EPF/Config.cpp
+++ b/BNA_KC_OPFOR/EPF/Config.cpp
@@ -13,6 +13,7 @@ class CfgWeapons
     {
         displayName = "[EPF] Helmet";
         hiddenSelectionsTextures[] = {"\sc_equipment\data\enforcer\textures\helmet_olive_co.paa"};
+        class ItemInfo;
     };
 
     class BNA_KC_TU_Helmet_Assault;
@@ -47,6 +48,22 @@ class CfgWeapons
         hiddenSelectionsTextures[] = {"sc_equipment\data\watchdog\textures\helmet_co.paa"};
     };
 
+    class BNA_KC_EPF_Helmet_Presidente: BNA_KC_EPF_Helmet
+    {
+        displayName = "[EPF] El Presidente Cap";
+        model = "\A3\Characters_F_AoW\Headgear\ParadeDressCap_01_F.p3d";
+        hiddenSelections[] = {"camo"};
+        hiddenSelectionsTextures[] = {"\a3\Characters_F_AoW\Headgear\Data\ParadeDressCap_01_US_F_CO.paa"};
+        hiddenSelectionsMaterials[] = {"\a3\Characters_F_AoW\Headgear\Data\ParadeDressCap_01_US_F.rvmat"};
+        picture = "\A3\Characters_F_AoW\Headgear\Data\UI\icon_H_ParadeDressCap_01_US_F_CA.paa";
+
+        class ItemInfo: ItemInfo
+        {
+            hiddenSelections[] = {"camo"};
+            uniformModel = "\A3\Characters_F_AoW\Headgear\ParadeDressCap_01_F.p3d";
+        };
+    };
+
     // ┌────────────────────┐
     // │      Uniforms      │
     // └────────────────────┘
@@ -58,10 +75,18 @@ class CfgWeapons
     class BNA_KC_EPF_Uniform: BNA_KC_TU_Uniform
     {
         displayName = "[EPF] Uniform";
-
         class ItemInfo: ItemInfo
         {
             uniformClass = "BNA_KC_EPF_Unit_Base";
+        };
+    };
+
+    class BNA_KC_EPF_Uniform_Presidente: BNA_KC_EPF_Uniform
+    {
+        displayName = "[EPF] El Preidente Uniform";
+        class ItemInfo: ItemInfo
+        {
+            uniformClass = "BNA_KC_EPF_Unit_Presidente";
         };
     };
 

--- a/BNA_KC_OPFOR/EPF/Config.cpp
+++ b/BNA_KC_OPFOR/EPF/Config.cpp
@@ -159,3 +159,17 @@ class CfgFactionClasses
         displayName = "[KC] El Presidente Forces";
     };
 };
+
+
+class CfgIdentities
+{
+    class ElPresidente
+    {
+        face = "PersianHead_A3_02";
+        glasses = "None";
+        name = "El Presidente";
+        nameSound = "El Presidente";
+        pitch = 1;
+        speaker = "Male01ENG";
+    };
+};

--- a/BNA_KC_OPFOR/EPF/Config.cpp
+++ b/BNA_KC_OPFOR/EPF/Config.cpp
@@ -85,7 +85,7 @@ class CfgWeapons
         displayName = "[EPF] Uniform";
         class ItemInfo: ItemInfo
         {
-            uniformClass = "BNA_KC_EPF_Unit_Base";
+            uniformClass = "BNA_KC_EPF_Unit_Rifleman";
         };
     };
 

--- a/BNA_KC_OPFOR/EPF/Config.cpp
+++ b/BNA_KC_OPFOR/EPF/Config.cpp
@@ -64,6 +64,14 @@ class CfgWeapons
         };
     };
 
+    class BNA_KC_EPF_Helmet_General: BNA_KC_EPF_Helmet_Presidente
+    {
+        displayName = "[EPF] El General Cap";
+        hiddenSelectionsTextures[] = {"\a3\Characters_F_AoW\Headgear\Data\ParadeDressCap_01_AAF_F_CO.paa"};
+        hiddenSelectionsMaterials[] = {"\a3\Characters_F_AoW\Headgear\Data\ParadeDressCap_01_AAF_F.rvmat"};
+        picture = "\A3\Characters_F_AoW\Headgear\Data\UI\icon_H_ParadeDressCap_01_AAF_F_CA.paa";
+    };
+
     // ┌────────────────────┐
     // │      Uniforms      │
     // └────────────────────┘
@@ -87,6 +95,15 @@ class CfgWeapons
         class ItemInfo: ItemInfo
         {
             uniformClass = "BNA_KC_EPF_Unit_Presidente";
+        };
+    };
+
+    class BNA_KC_EPF_Uniform_General: BNA_KC_EPF_Uniform
+    {
+        displayName = "[EPF] El General Uniform";
+        class ItemInfo: ItemInfo
+        {
+            uniformClass = "BNA_KC_EPF_Unit_General";
         };
     };
 

--- a/BNA_KC_OPFOR/EPF/Config.cpp
+++ b/BNA_KC_OPFOR/EPF/Config.cpp
@@ -208,4 +208,11 @@ class CfgIdentities
         pitch = 1;
         speaker = "Male01ENG";
     };
+
+    class ElGeneral: ElPresidente
+    {
+        face = "GreekHead_A3_04";
+        name = "El General";
+        nameSound = "El General";
+    };
 };

--- a/BNA_KC_OPFOR/EPF/Config.cpp
+++ b/BNA_KC_OPFOR/EPF/Config.cpp
@@ -115,6 +115,7 @@ class CfgWeapons
     {
         displayName = "[EPF] Light Vest";
         hiddenSelectionsTextures[] = {"\sc_equipment\data\watchdog\textures\vest_co.paa"};
+        class ItemInfo;
     };
 
     class BNA_KC_TU_Vest_Medium;
@@ -140,6 +141,24 @@ class CfgWeapons
     {
         displayName = "[EPF] Heavy Assault Vest";
         hiddenSelectionsTextures[] = {"\sc_equipment\data\watchdog\textures\vest_co.paa"};
+    };
+
+    class BNA_KC_EPF_Vest_General: BNA_KC_EPF_Vest
+    {
+        displayName = "[EPF] El General Vest";
+        model = "\sc_equipment\data\samurai\sam_vest_light.p3d";
+        hiddenSelections[] = {"camo", "camo1"};
+        hiddenSelectionsTextures[] =
+        {
+            "\sc_equipment\data\samurai\textures\torso_black_co.paa",
+            "\sc_equipment\data\samurai\textures\legs_black_co.paa"
+        };
+
+        class ItemInfo: ItemInfo
+        {
+            hiddenSelections[] = {"camo", "camo1"};
+            uniformModel = "\sc_equipment\data\samurai\sam_vest_light.p3d";
+        };
     };
 };
 


### PR DESCRIPTION
### Description
Spawnable units for El Presidente and El General

### Changes
- Added El Presidente Uniform, Helmet, and Unit
- Added El General Uniform, Helmet, Vest, and Unit
- Fixed `uniformClass` for base EPF uniform
  - Was referecning `BNA_KC_EPF_Unit_Base`, which does not exist
- Added macros for sides (`BLUFOR`, `OPFOR`, etc.)