### PR TITLE
Moved core mods to html preset

### DIFF
--- a/.hemtt/presets/main.html
+++ b/.hemtt/presets/main.html
@@ -1,0 +1,250 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<html>
+  <!--Created by Arma 3 Launcher: https://arma3.com-->
+
+  <head>
+    <meta name="arma:Type" content="preset"/>
+    <meta name="arma:PresetName" content="KC Test"/>
+    <meta name="generator" content="Arma 3 Launcher - https://arma3.com"/>
+    <title>Arma 3</title>
+    <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type="text/css"/>
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+        color: #fff;
+        background: #000;
+      }
+
+      body,
+      td,
+      th {
+        font: 95%/1.3 Roboto, Segoe UI, Tahoma, Arial, Helvetica, sans-serif;
+      }
+
+      td {
+        padding: 3px 30px 3px 0;
+      }
+
+      h1 {
+        padding: 20px 20px 0;
+        color: white;
+        font-weight: 200;
+        font-family: segoe ui;
+        font-size: 3em;
+        margin: 0;
+      }
+
+      em {
+        font-variant: italic;
+        color: silver;
+      }
+
+      .before-list {
+        padding: 5px 20px 10px;
+      }
+
+      .mod-list {
+        background: #222222;
+        padding: 20px;
+      }
+
+      .dlc-list {
+        background: #222222;
+        padding: 20px;
+      }
+
+      .footer {
+        padding: 20px;
+        color: gray;
+      }
+
+      .whups {
+        color: gray;
+      }
+
+      a {
+        color: #D18F21;
+        text-decoration: underline;
+      }
+
+      a:hover {
+        color: #F1AF41;
+        text-decoration: none;
+      }
+
+      .from-steam {
+        color: #449EBD;
+      }
+
+      .from-local {
+        color: gray;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1>
+      <strong>Keeli Company Aux</strong>
+      - Main Dependencies
+    </h1>
+    <p class="before-list">
+      <em>To import this preset, drag this file onto the Launcher window. Or click the MODS tab, then PRESET in the top right, then IMPORT at the bottom, and finally select this file.</em>
+    </p>
+    <div class="mod-list">
+      <table>
+        <tr data-type="ModContainer">
+          <td data-type="DisplayName">CBA_A3</td>
+          <td>
+            <span class="from-steam">Steam</span>
+          </td>
+          <td>
+            <a href="http://steamcommunity.com/sharedfiles/filedetails/?id=450814997" data-type="Link">http://steamcommunity.com/sharedfiles/filedetails/?id=450814997</a>
+          </td>
+        </tr>
+        <tr data-type="ModContainer">
+          <td data-type="DisplayName">Just Like The Simulations - The Great War</td>
+          <td>
+            <span class="from-steam">Steam</span>
+          </td>
+          <td>
+            <a href="http://steamcommunity.com/sharedfiles/filedetails/?id=1940589429" data-type="Link">http://steamcommunity.com/sharedfiles/filedetails/?id=1940589429</a>
+          </td>
+        </tr>
+        <tr data-type="ModContainer">
+          <td data-type="DisplayName">3AS (Beta Test)</td>
+          <td>
+            <span class="from-steam">Steam</span>
+          </td>
+          <td>
+            <a href="https://steamcommunity.com/sharedfiles/filedetails/?id=2058554822" data-type="Link">https://steamcommunity.com/sharedfiles/filedetails/?id=2058554822</a>
+          </td>
+        </tr>
+        <tr data-type="ModContainer">
+          <td data-type="DisplayName">Kobra Mod Pack - Main</td>
+          <td>
+            <span class="from-steam">Steam</span>
+          </td>
+          <td>
+            <a href="http://steamcommunity.com/sharedfiles/filedetails/?id=1393068220" data-type="Link">http://steamcommunity.com/sharedfiles/filedetails/?id=1393068220</a>
+          </td>
+        </tr>
+        <tr data-type="ModContainer">
+          <td data-type="DisplayName">Operation TREBUCHET</td>
+          <td>
+            <span class="from-steam">Steam</span>
+          </td>
+          <td>
+            <a href="http://steamcommunity.com/sharedfiles/filedetails/?id=769440155" data-type="Link">http://steamcommunity.com/sharedfiles/filedetails/?id=769440155</a>
+          </td>
+        </tr>
+        <tr data-type="ModContainer">
+          <td data-type="DisplayName">Legion Studios Base - Stable</td>
+          <td>
+            <span class="from-steam">Steam</span>
+          </td>
+          <td>
+            <a href="http://steamcommunity.com/sharedfiles/filedetails/?id=2162749089" data-type="Link">http://steamcommunity.com/sharedfiles/filedetails/?id=2162749089</a>
+          </td>
+        </tr>
+        <tr data-type="ModContainer">
+          <td data-type="DisplayName">ace</td>
+          <td>
+            <span class="from-steam">Steam</span>
+          </td>
+          <td>
+            <a href="https://steamcommunity.com/sharedfiles/filedetails/?id=463939057" data-type="Link">https://steamcommunity.com/sharedfiles/filedetails/?id=463939057</a>
+          </td>
+        </tr>
+        <tr data-type="ModContainer">
+          <td data-type="DisplayName">Improved Melee System</td>
+          <td>
+            <span class="from-steam">Steam</span>
+          </td>
+          <td>
+            <a href="http://steamcommunity.com/sharedfiles/filedetails/?id=2291129343" data-type="Link">http://steamcommunity.com/sharedfiles/filedetails/?id=2291129343</a>
+          </td>
+        </tr>
+        <tr data-type="ModContainer">
+          <td data-type="DisplayName">501st Community Auxiliary Mod [Official]</td>
+          <td>
+            <span class="from-steam">Steam</span>
+          </td>
+          <td>
+            <a href="https://steamcommunity.com/sharedfiles/filedetails/?id=2173635424" data-type="Link">https://steamcommunity.com/sharedfiles/filedetails/?id=2173635424</a>
+          </td>
+        </tr>
+        <tr data-type="ModContainer">
+          <td data-type="DisplayName">Legion Studios - Star Wars Battlefields</td>
+          <td>
+            <span class="from-steam">Steam</span>
+          </td>
+          <td>
+            <a href="http://steamcommunity.com/sharedfiles/filedetails/?id=2320596778" data-type="Link">http://steamcommunity.com/sharedfiles/filedetails/?id=2320596778</a>
+          </td>
+        </tr>
+        <tr data-type="ModContainer">
+          <td data-type="DisplayName">Lightsabers and Force</td>
+          <td>
+            <span class="from-steam">Steam</span>
+          </td>
+          <td>
+            <a href="http://steamcommunity.com/sharedfiles/filedetails/?id=2323185592" data-type="Link">http://steamcommunity.com/sharedfiles/filedetails/?id=2323185592</a>
+          </td>
+        </tr>
+        <tr data-type="ModContainer">
+          <td data-type="DisplayName">Task Force Arrowhead Radio (BETA!!!)</td>
+          <td>
+            <span class="from-steam">Steam</span>
+          </td>
+          <td>
+            <a href="https://steamcommunity.com/sharedfiles/filedetails/?id=894678801" data-type="Link">https://steamcommunity.com/sharedfiles/filedetails/?id=894678801</a>
+          </td>
+        </tr>
+        <tr data-type="ModContainer">
+          <td data-type="DisplayName">3AS Terrains (Beta)</td>
+          <td>
+            <span class="from-steam">Steam</span>
+          </td>
+          <td>
+            <a href="http://steamcommunity.com/sharedfiles/filedetails/?id=2215872933" data-type="Link">http://steamcommunity.com/sharedfiles/filedetails/?id=2215872933</a>
+          </td>
+        </tr>
+        <tr data-type="ModContainer">
+          <td data-type="DisplayName">Last Force Project</td>
+          <td>
+            <span class="from-steam">Steam</span>
+          </td>
+          <td>
+            <a href="http://steamcommunity.com/sharedfiles/filedetails/?id=2061309401" data-type="Link">http://steamcommunity.com/sharedfiles/filedetails/?id=2061309401</a>
+          </td>
+        </tr>
+        <tr data-type="ModContainer">
+          <td data-type="DisplayName">Legion Base: Task Force Arrowhead Radio BETA Compatibility patch</td>
+          <td>
+            <span class="from-steam">Steam</span>
+          </td>
+          <td>
+            <a href="http://steamcommunity.com/sharedfiles/filedetails/?id=1969012355" data-type="Link">http://steamcommunity.com/sharedfiles/filedetails/?id=1969012355</a>
+          </td>
+        </tr>
+        <tr data-type="ModContainer">
+          <td data-type="DisplayName">Just Like The Simulations - The Great War - TFAR beta compatibility</td>
+          <td>
+            <span class="from-steam">Steam</span>
+          </td>
+          <td>
+            <a href="http://steamcommunity.com/sharedfiles/filedetails/?id=2332457910" data-type="Link">http://steamcommunity.com/sharedfiles/filedetails/?id=2332457910</a>
+          </td>
+        </tr>
+      </table>
+    </div>
+    <div class="dlc-list">
+      <table/>
+    </div>
+    <div class="footer">
+      <span>Created by Arma 3 Launcher by Bohemia Interactive.</span>
+    </div>
+  </body>
+
+</html>

--- a/.hemtt/project.toml
+++ b/.hemtt/project.toml
@@ -13,13 +13,9 @@ include = [
     "meta.cpp",
     "logo_kc_ca.paa",
     # "LICENSE",
-    "README.md"
+    "README.md",
 ]
-exclude = [
-    "*.spp",
-    "*.spp.painter_lock",
-    "*.psd"
-]
+exclude = ["*.spp", "*.spp.painter_lock", "*.psd"]
 
 [properties]
 author = "DartRuffian"
@@ -27,103 +23,55 @@ url = "https://github.com/DartRuffian/KeeliCompanyAux"
 
 [hemtt.launch.default]
 workshop = [
-    "450814997",  # CBA
-    "463939057",  # ACE
-    "894678801",  # TFAR
     "2369477168", # ADT
     "623475643",  # 3DEN
     "1779063631", # ZEN
     "2018593688", # ZEN ACE Compat
-    "1940589429", # JLTS
-    "2332457910", # JLTS TFAR
-    "2058554822", # 3AS
-    "2215872933", # 3AS Terrains
-    "2162749089", # LS
-    "1969012355", # LS TFAR
-    "2320596778", # LS Battlefields
-    "2291129343", # Improved Melee System
-    "2567352444", # WBK Droids
-    "2061309401", # LFP
-    "1393068220", # Kobra
-    "769440155",  # OPTRE
-    "2173635424", # 501st Aux
-    "767380317"   # Blastcore # Only used to test particle effects
+    # "2567352444", # WBK Droids # ! Not currently used
+    "767380317", # Blastcore # Only used to test particle effects
 ]
-presets = []
+presets = ["main"]
 dlc = []
 optionals = ["dev"]
 parameters = ["ORA\\BNA_KC\\addons\\dev\\missions\\AuxTest.VR\\mission.sqm"]
 
 [hemtt.launch.full]
 workshop = [
-    "450814997",  # CBA
-    "463939057",  # ACE
-    "894678801",  # TFAR
     "2369477168", # ADT
     "623475643",  # 3DEN
     "1779063631", # ZEN
     "2018593688", # ZEN ACE Compat
-    "1940589429", # JLTS
-    "2332457910", # JLTS TFAR
-    "2058554822", # 3AS
-    "2215872933", # 3AS Terrains
-    "2162749089", # LS
-    "1969012355", # LS TFAR
-    "2320596778", # LS Battlefields
     # "1686872930", # SDT # ! Not currently used
-    "2291129343", # Improved Melee System
-    "2567352444", # WBK Droids
-    "2061309401", # LFP
-    "1393068220", # Kobra
-    "2306758518", # Kobra LS
-    "2323185592", # Lightsabers and Force
-    "769440155",  # OPTRE
+    # "2567352444", # WBK Droids # ! Not currently used
     "1572627279", # OPTRE First Contact
-    "2173635424", # 501st Aux
     "2915485125", # Burn 'Em
     "767380317",  # Blastcore
     "2789152015", # WBK Zombies
-    "2478080991"  # Scion Conflict
+    "2478080991", # Scion Conflict
 ]
-presets = []
+presets = ["main"]
 dlc = []
 optionals = ["dev"]
 parameters = ["ORA\\BNA_KC\\addons\\dev\\missions\\AuxTest.VR\\mission.sqm"]
 
 [hemtt.launch.previews]
 workshop = [
-    "450814997",  # CBA
-    "463939057",  # ACE
-    "894678801",  # TFAR
     "2369477168", # ADT
     "623475643",  # 3DEN
     "1779063631", # ZEN
     "2018593688", # ZEN ACE Compat
-    "1940589429", # JLTS
-    "2058554822", # 3AS
-    "2215872933", # 3AS Terrains
-    "2162749089", # LS
-    "1969012355", # LS TFAR
-    "2320596778", # LS Battlefields
-    "1686872930", # SDT
-    "2567352444", # WBK Droids
-    "2061309401", # LFP
-    "1393068220", # Kobra
-    "2306758518", # Kobra LS
-    "2291129343", # Improved Melee System
-    "2323185592", # Lightsabers and Force
-    "769440155",  # OPTRE
+    # "1686872930", # SDT # ! Not currently used
+    # "2567352444", # WBK Droids # ! Not currently used
     "1572627279", # OPTRE First Contact
-    "2173635424", # 501st Aux
     "2915485125", # Burn 'Em
     "767380317",  # Blastcore
     "2789152015", # WBK Zombies
-    "2478080991"  # Scion Conflict
+    "2478080991", # Scion Conflict
 ]
 presets = []
 dlc = []
 optionals = []
 parameters = [
     "C:\\Users\\skull\\OneDrive\\Documents\\Arma 3 - Other Profiles\\Previews\\missions\\Previews.VR\\mission.sqm",
-    "-name=Previews"
+    "-name=Previews",
 ]


### PR DESCRIPTION
## Description
Moved core mod requirements to a .html preset instead of specifying all of their workshop ids.

## Changes
**Tools**
- Moved core mod requirements to  `.hemtt\presets\main.html`.
- All launch presets use `presets = ["main"]`.
- Updated formatting for `project.toml`.