### PR TITLE
AT-RT Bug Fixes

### DIFF
--- a/addons/vehicles/CfgEventHandlers.hpp
+++ b/addons/vehicles/CfgEventHandlers.hpp
@@ -19,6 +19,7 @@ class Extended_PostInit_EventHandlers
     class ADDON
     {
         clientInit = QUOTE(call COMPILE_SCRIPT(XEH_postInitClient));
+        serverInit = QUOTE(call COMPILE_SCRIPT(XEH_postInitServer));
     };
 };
 

--- a/addons/vehicles/XEH_postInitClient.sqf
+++ b/addons/vehicles/XEH_postInitClient.sqf
@@ -1,17 +1,19 @@
 #include "script_component.hpp"
 
-[QGVAR(autoEject), {
-    params ["_unit"];
-    if (_unit isNotEqualTo ace_player) exitWith {};
-    INFO_1("Ejecting player from vehicle",_unit);
+["CBA_settingsInitialized", {
+    [QGVAR(autoEject), {
+        params ["_unit"];
+        if (_unit isNotEqualTo ace_player) exitWith {};
+        INFO_1("Ejecting player from vehicle",_unit);
 
-    if (GVAR(autoEject_invincibleTimer) > 0) then {
-        _unit allowDamage false;
-        [{_this allowDamage true;}, _unit, GVAR(autoEject_invincibleTimer)] call CBA_fnc_waitAndExecute;
-    };
+        if (GVAR(autoEject_invincibleTimer) > 0) then {
+            _unit allowDamage false;
+            [{_this allowDamage true;}, _unit, GVAR(autoEject_invincibleTimer)] call CBA_fnc_waitAndExecute;
+        };
 
-    if (alive _unit and {(_unit getVariable ["ace_isUnconscious", false])}) then {
-        "You have been ejected." call ace_common_fnc_displayTextStructured;
-        moveOut _unit;
-    };
+        if (alive _unit and {(_unit getVariable ["ace_isUnconscious", false])}) then {
+            "You have been ejected." call ace_common_fnc_displayTextStructured;
+            moveOut _unit;
+        };
+    }] call CBA_fnc_addEventHandler;
 }] call CBA_fnc_addEventHandler;

--- a/addons/vehicles/XEH_postInitClient.sqf
+++ b/addons/vehicles/XEH_postInitClient.sqf
@@ -16,4 +16,13 @@
             moveOut _unit;
         };
     }] call CBA_fnc_addEventHandler;
+
+    ["ace_unconscious", {
+        params ["_unit", "_state"];
+        private ["_atrt"];
+        TRACE_2("ace_unconscious",_unit,_state);
+
+        _atrt = _unit getVariable [QGVAR(atrt_riding), objNull];
+        _atrt call FUNC(atrt_dismount);
+    }] call CBA_fnc_addEventHandler;
 }] call CBA_fnc_addEventHandler;

--- a/addons/vehicles/XEH_postInitServer.sqf
+++ b/addons/vehicles/XEH_postInitServer.sqf
@@ -1,0 +1,12 @@
+#include "script_component.hpp"
+
+["CBA_settingsInitialized", {
+    ["ace_unconscious", {
+        params ["_unit", "_state"];
+        private ["_atrt"];
+        TRACE_2("ace_unconscious",_unit,_state);
+
+        _atrt = _unit getVariable [QGVAR(atrt_riding), objNull];
+        _atrt call FUNC(atrt_dismount);
+    }] call CBA_fnc_addEventHandler;
+}] call CBA_fnc_addEventHandler;

--- a/addons/vehicles/air/laatc/CfgVehicles.hpp
+++ b/addons/vehicles/air/laatc/CfgVehicles.hpp
@@ -100,7 +100,7 @@ class CfgVehicles
             class LoadVehicle: Impulse
             {
                 displayName = "Load Vehicle";
-                condition = QUOTE(ace_player isEqualTo currentPilot this and this call FUNC(vivCanLoad));
+                condition = QUOTE(ace_player isEqualTo currentPilot this and {this call FUNC(vivCanLoad)});
                 statement = QUOTE(this call FUNC(vivLoad));
             };
         };

--- a/addons/vehicles/air/laati/CfgVehicles.hpp
+++ b/addons/vehicles/air/laati/CfgVehicles.hpp
@@ -215,6 +215,13 @@ class CfgVehicles
                 condition = QUOTE(ace_player == currentPilot this and this animationSourcePhase 'ramp' == 1;);
                 statement = QUOTE([ARR_2('ramp',true)] call ls_fnc_keybind_operationFrameWork;);
             };
+
+            class LoadVehicle: Impulse
+            {
+                displayName = "Load Vehicle";
+                condition = QUOTE(ace_player isEqualTo currentPilot this and {this call FUNC(vivCanLoad)});
+                statement = QUOTE(this call FUNC(vivLoad));
+            };
         };
 
         class AnimationSources: AnimationSources

--- a/addons/vehicles/functions/fnc_atrt_canDismount.sqf
+++ b/addons/vehicles/functions/fnc_atrt_canDismount.sqf
@@ -9,7 +9,7 @@
  * 1: The unit attempting to dismount the AT-RT <OBJECT>
  *
  * Return Value:
- * Whether the given unit can dismount the AT-RT <BOOL>
+ * True if the AT-RT can be dismounted, otherwise false <BOOL>
  *
  * Examples:
  * [_atrt, ace_player] call FUNC(atrt_canDismount);

--- a/addons/vehicles/functions/fnc_atrt_canDismount.sqf
+++ b/addons/vehicles/functions/fnc_atrt_canDismount.sqf
@@ -24,6 +24,6 @@ params [
 private [];
 TRACE_2("fnc_atrt_canDismount",_atrt,_unit);
 
-if (_unit isEqualTo (_atrt getVariable [QGVAR(rider), objNull])) exitWith {true};
+if (_unit isEqualTo (_atrt getVariable [QGVAR(atrt_rider), objNull])) exitWith {true};
 
 false;

--- a/addons/vehicles/functions/fnc_atrt_canDismount.sqf
+++ b/addons/vehicles/functions/fnc_atrt_canDismount.sqf
@@ -24,6 +24,6 @@ params [
 private [];
 TRACE_2("fnc_atrt_canDismount",_atrt,_unit);
 
-if (_unit isEqualTo (_atrt getVariable [QGVAR(atrt_rider), objNull])) exitWith {true};
+if (_unit isEqualTo (_atrt getVariable ["TAS_ATRT_rider", objNull])) exitWith {true};
 
 false;

--- a/addons/vehicles/functions/fnc_atrt_canMount.sqf
+++ b/addons/vehicles/functions/fnc_atrt_canMount.sqf
@@ -27,7 +27,7 @@ TRACE_2("fnc_atrt_canMount",_atrt,_unit);
 if (!alive _atrt or {
     _unit isKindOf "3AS_ATRT_Base" or
     !(_unit call ace_common_fnc_isAwake) or
-    !(isNull (_atrt getVariable [QGVAR(rider), objNull]))
+    !(isNull (_atrt getVariable [QGVAR(atrt_rider), objNull]))
 }) exitWith {false};
 
 true;

--- a/addons/vehicles/functions/fnc_atrt_canMount.sqf
+++ b/addons/vehicles/functions/fnc_atrt_canMount.sqf
@@ -27,7 +27,7 @@ TRACE_2("fnc_atrt_canMount",_atrt,_unit);
 if (!alive _atrt or {
     _unit isKindOf "3AS_ATRT_Base" or
     !(_unit call ace_common_fnc_isAwake) or
-    !(isNull (_atrt getVariable [QGVAR(atrt_rider), objNull]))
+    !(isNull (_atrt getVariable ["TAS_ATRT_rider", objNull]))
 }) exitWith {false};
 
 true;

--- a/addons/vehicles/functions/fnc_atrt_canMount.sqf
+++ b/addons/vehicles/functions/fnc_atrt_canMount.sqf
@@ -9,7 +9,7 @@
  * 1: The unit attempting to ride the AT-RT <OBJECT>
  *
  * Return Value:
- * Whether the given unit can ride the AT-RT <BOOL>
+ * True if the AT-RT can be mounted, otherwise false  <BOOL>
  *
  * Examples:
  * [_atrt, ace_player] call FUNC(atrt_canMount);

--- a/addons/vehicles/functions/fnc_atrt_deathEffects.sqf
+++ b/addons/vehicles/functions/fnc_atrt_deathEffects.sqf
@@ -39,8 +39,8 @@ _sparks setParticleClass "3AS_ImpactSparksPlasma1";
 _sparks setDropInterval 0.05;
 _sparks attachTo [_atrt, [0, 0, 0], _memPoint];
 
-_effects = _atrt getVariable [QGVAR(atrt_deathEffects), []];
+_effects = _atrt getVariable ["TAS_ATRT_effects", []];
 _effects append [_smoke, _sparks];
 
-_atrt setVariable [QGVAR(atrt_deathEffects), _effects, true];
+_atrt setVariable ["TAS_ATRT_effects", _effects, true];
 _effects;

--- a/addons/vehicles/functions/fnc_atrt_dismount.sqf
+++ b/addons/vehicles/functions/fnc_atrt_dismount.sqf
@@ -2,11 +2,10 @@
 /*
  * Author: 3AS
  * Edited by DartRuffian
- * Mounts a unit on an AT-RT
+ * Dismounts an AT-RT.
  *
  * Arguments:
  * 0: The AT-RT <OBJECT>
- * 1: The unit dismounting the AT-RT <OBJECT>
  *
  * Return Value:
  * None

--- a/addons/vehicles/functions/fnc_atrt_dismount.sqf
+++ b/addons/vehicles/functions/fnc_atrt_dismount.sqf
@@ -23,11 +23,12 @@ params [
 private ["_rider", "_direction", "_positionATL"];
 TRACE_1("fnc_atrt_dismount",_atrt);
 
-_rider = _atrt getVariable [QGVAR(rider), objNull];
+_rider = _atrt getVariable [QGVAR(atrt_rider), objNull];
 if (isNull _rider) exitWith {};
 
 _atrt disableAI "ANIM";
-_atrt setVariable [QGVAR(rider), objNull, true];
+_atrt setVariable [QGVAR(atrt_rider), objNull];
+_rider setVariable [QGVAR(atrt_riding), objNull];
 _rider setVariable [QGVAR(atrt_isRiding), false, true];
 
 _direction = direction _atrt;

--- a/addons/vehicles/functions/fnc_atrt_dismount.sqf
+++ b/addons/vehicles/functions/fnc_atrt_dismount.sqf
@@ -22,13 +22,13 @@ params [
 private ["_rider", "_direction", "_positionATL"];
 TRACE_1("fnc_atrt_dismount",_atrt);
 
-_rider = _atrt getVariable [QGVAR(atrt_rider), objNull];
+_rider = _atrt getVariable ["TAS_ATRT_rider", objNull];
 if (isNull _rider) exitWith {};
 
 _atrt disableAI "ANIM";
-_atrt setVariable [QGVAR(atrt_rider), objNull];
+_atrt setVariable ["TAS_ATRT_rider", objNull];
 _rider setVariable [QGVAR(atrt_riding), objNull];
-_rider setVariable [QGVAR(atrt_isRiding), false, true];
+_rider setVariable ["TAS_ATRT_isRiding", false, true];
 
 _direction = direction _atrt;
 _positionATL = getPosATL _atrt;
@@ -47,7 +47,7 @@ _rider remoteControl objNull;
 
 inGameUISetEventHandler ["Action", ""];
 
-[_rider, "blockThrow", QGVAR(atrt_isRiding), false] call ace_common_fnc_statusEffect_set;
+[_rider, "blockThrow", "TAS_ATRT_isRiding", false] call ace_common_fnc_statusEffect_set;
 
 [_rider, ""] remoteExec ["switchMove"];
 

--- a/addons/vehicles/functions/fnc_atrt_init.sqf
+++ b/addons/vehicles/functions/fnc_atrt_init.sqf
@@ -46,6 +46,6 @@ _atrt addEventHandler ["HandleDamage", LINKFUNC(atrt_handleDamage)];
 _atrt addEventHandler ["Deleted", {
     params ["_entity"];
     private ["_allEffects"];
-    _allEffects = _entity getVariable [QGVAR(atrt_deathEffects), []];
+    _allEffects = _entity getVariable ["TAS_ATRT_effects", []];
     { deleteVehicle _x; } forEach _allEffects;
 }];

--- a/addons/vehicles/functions/fnc_atrt_mount.sqf
+++ b/addons/vehicles/functions/fnc_atrt_mount.sqf
@@ -25,7 +25,8 @@ private [];
 TRACE_2("fnc_atrt_mount",_atrt,_rider);
 
 _atrt enableAI "ANIM";
-_atrt setVariable [QGVAR(rider), _rider, true];
+_atrt setVariable [QGVAR(atrt_rider), _rider];
+_rider setVariable [QGVAR(atrt_riding), _atrt];
 _rider setVariable [QGVAR(atrt_isRiding), true, true];
 
 _rider attachTo [_atrt, [0, 0, 0], "seat"];

--- a/addons/vehicles/functions/fnc_atrt_mount.sqf
+++ b/addons/vehicles/functions/fnc_atrt_mount.sqf
@@ -25,9 +25,9 @@ private [];
 TRACE_2("fnc_atrt_mount",_atrt,_rider);
 
 _atrt enableAI "ANIM";
-_atrt setVariable [QGVAR(atrt_rider), _rider];
+_atrt setVariable ["TAS_ATRT_rider", _rider];
 _rider setVariable [QGVAR(atrt_riding), _atrt];
-_rider setVariable [QGVAR(atrt_isRiding), true, true];
+_rider setVariable ["TAS_ATRT_isRiding", true, true];
 
 _rider attachTo [_atrt, [0, 0, 0], "seat"];
 [_rider, "ChopperLight_C_LIn_H"] remoteExec ["switchMove"];
@@ -36,11 +36,11 @@ _atrt switchCamera cameraView;
 _rider remoteControl _atrt;
 inGameUISetEventHandler ["Action", "if ((_this select 3) isEqualTo ""BackFromUAV"") then {true};"]; // Disables "Release UAV Controls" action
 
-[_rider, "blockThrow", QGVAR(atrt_isRiding), true] call ace_common_fnc_statusEffect_set;
+[_rider, "blockThrow", "TAS_ATRT_isRiding", true] call ace_common_fnc_statusEffect_set;
 
 [{
     // Prevent animation if mounting and dismounting quickly
-    if (_this getVariable [QGVAR(atrt_isRiding), false]) then {
+    if (_this getVariable ["TAS_ATRT_isRiding", false]) then {
         [_this, "driver_Quadbike"] remoteExec ["switchMove"];
     }
 }, _rider, 1.5] call CBA_fnc_waitAndExecute;


### PR DESCRIPTION
## Description
Fixed players not being dismounted when they are knocked unconscious on an AT-RT. Also fixed the LAAT/i not being able to load AT-RTs.

## Changes
- Added event handler to dismount unconscious units.
- Fixed missing `LoadVehicle` action on LAAT/i.
- Updated variable names to match 3AS ones for compatibility
  - `BNA_KC_vehicles_atrt_isRiding` -> `TAS_ATRT_isRiding`, etc.