### PR TITLE
Updated vest/item names

### DIFF
--- a/addons/armor/CfgWeapons.hpp
+++ b/addons/armor/CfgWeapons.hpp
@@ -272,7 +272,7 @@ class CfgWeapons
 
     class CLASS(NVG_phase2_Rangefinder): CLASS(NVG_phase1_Rangefinder)
     {
-        displayName = "[KC] Clone P2 Rangefinder (CS+)";
+        displayName = "[KC] Clone P2 Rangefinder";
 
         model = "\lsd_equipment_bluefor\nvg\gar\lsd_gar_rangefinder_nvg_on.p3d";
         hiddenSelectionsTextures[] = {QPATHTOF(data\nvgs\rangefinder_camo1_co.paa)};
@@ -286,7 +286,7 @@ class CfgWeapons
 
     class CLASS(NVG_phase1_Officer): CLASS(NVG_Chip)
     {
-        displayName = "[KC] Clone P1 Officer Visor (WO+)";
+        displayName = "[KC] Clone P1 Officer Visor";
 
         model = "\lsd_equipment_bluefor\accessories\gar\commander\lsd_gar_p1Commander_nvg";
         hiddenSelections[] = {"camo1", "camo2", "camo3"};
@@ -308,7 +308,7 @@ class CfgWeapons
 
     class CLASS(NVG_phase2_Officer): CLASS(NVG_phase1_Officer)
     {
-        displayName = "[KC] Clone P2 Officer Visor (WO+)";
+        displayName = "[KC] Clone P2 Officer Visor";
 
         model = "\lsd_equipment_bluefor\accessories\gar\commander\lsd_gar_p2Commander_nvg";
         hiddenSelectionsTextures[] = {QPATHTOF(data\nvgs\officer_camo1_co.paa)};

--- a/addons/armor/configs/GroundHolders.hpp
+++ b/addons/armor/configs/GroundHolders.hpp
@@ -29,7 +29,7 @@ GROUND_HOLDER(Helmet_Engineer_Enlisted_CamoGrey,"ENG Helm 01 (Enlisted) - Grey C
 
 GROUND_HOLDER(Helmet_Phase1_Pilot_Base,"AVI P1 Helm (Base)");
 GROUND_HOLDER(Helmet_Phase1Geo_Pilot,"AVI GEO Helm");
-GROUND_HOLDER(Helmet_Phase1_Pilot_CXA,"AVI P1 Helm 01+ (Airman)");
+GROUND_HOLDER(Helmet_Phase1_Pilot_CXA,"AVI P1 Helm 01 (Airman)");
 
 GROUND_HOLDER(Helmet_Phase1_Tanker_Base,"ARMR P1 Helm (Base)");
 GROUND_HOLDER(Helmet_Phase1_Tanker_CT,"ARMR P1 Helm 01 (Trooper)");
@@ -62,10 +62,10 @@ GROUND_HOLDER(Helmet_Phase1_Officer_CamoGrey,"INF P1 Helm 12+ (Officer) - Grey C
 GROUND_HOLDER(Helmet_Phase1_ARC_CT,"SF ARC P1 Helm 01 (Trooper)");
 
 GROUND_HOLDER(Helmet_Phase2_Pilot_Base,"AVI P2 Helm (Base)");
-GROUND_HOLDER(Helmet_Phase2_Pilot_CXA,"AVI P2 Helm 01+ (Airman)");
-GROUND_HOLDER(Helmet_Phase2_Pilot_CXE,"AVI P2 Helm 11+ (Ensign)");
-GROUND_HOLDER(Helmet_Phase2_Pilot_Officer_CamoBrown,"AVI P2 Helm 11+ (Officer) - Brown Camo");
-GROUND_HOLDER(Helmet_Phase2_Pilot_Officer_CamoGrey,"AVI P2 Helm 11+ (Officer) - Grey Camo");
+GROUND_HOLDER(Helmet_Phase2_Pilot_CXA,"AVI P2 Helm 01 (Airman)");
+GROUND_HOLDER(Helmet_Phase2_Pilot_CXE,"AVI P2 Helm 06 (Ensign)");
+GROUND_HOLDER(Helmet_Phase2_Pilot_Officer_CamoBrown,"AVI P2 Helm 02 (Officer) - Brown Camo");
+GROUND_HOLDER(Helmet_Phase2_Pilot_Officer_CamoGrey,"AVI P2 Helm 02 (Officer) - Grey Camo");
 
 GROUND_HOLDER(Helmet_Phase2_Tanker_Base,"ARMR P2 Helm (Base)");
 GROUND_HOLDER(Helmet_Phase2_Tanker_CT,"ARMR P2 Helm 01 (Trooper)");

--- a/addons/armor/configs/Helmets_P1_Pilot.hpp
+++ b/addons/armor/configs/Helmets_P1_Pilot.hpp
@@ -36,7 +36,7 @@ class CLASS(Helmet_Phase1Geo_Pilot): CLASS(Helmet_Phase1_Pilot_Base)
 
 class CLASS(Helmet_Phase1_Pilot_CXA): CLASS(Helmet_Phase1_Pilot_Base)
 {
-    displayName = "[KC] AVI P1 Helm 01+ (Airman)";
+    displayName = "[KC] AVI P1 Helm 01 (Airman)";
     hiddenSelectionsTextures[] =
     {
         QPATHTOF(data\helmets\phase1Pilot\CXA_camo1_co.paa),

--- a/addons/armor/configs/Helmets_P2_Pilot.hpp
+++ b/addons/armor/configs/Helmets_P2_Pilot.hpp
@@ -24,7 +24,7 @@ class CLASS(Helmet_Phase2_Pilot_Base): CLASS(Helmet_Base)
 
 class CLASS(Helmet_Phase2_Pilot_CXA): CLASS(Helmet_Phase2_Pilot_Base)
 {
-    displayName = "[KC] AVI P2 Helm 01+ (Airman)";
+    displayName = "[KC] AVI P2 Helm 01 (Airman)";
     hiddenSelectionsTextures[] =
     {
         QPATHTOF(data\helmets\phase2Pilot\CXA_camo1_co.paa),
@@ -34,7 +34,7 @@ class CLASS(Helmet_Phase2_Pilot_CXA): CLASS(Helmet_Phase2_Pilot_Base)
 
 class CLASS(Helmet_Phase2_Pilot_CXE): CLASS(Helmet_Phase2_Pilot_Base)
 {
-    displayName = "[KC] AVI P2 Helm 11+ (Ensign)";
+    displayName = "[KC] AVI P2 Helm 06 (Ensign)";
     hiddenSelectionsTextures[] =
     {
         QPATHTOF(data\helmets\phase2Pilot\CXE_camo1_co.paa),
@@ -44,7 +44,7 @@ class CLASS(Helmet_Phase2_Pilot_CXE): CLASS(Helmet_Phase2_Pilot_Base)
 
 class CLASS(Helmet_Phase2_Pilot_Officer_CamoBrown): CLASS(Helmet_Phase2_Pilot_CXE)
 {
-    displayName = "[KC] AVI P2 Helm 11+ (Officer) - Brown Camo";
+    displayName = "[KC] AVI P2 Helm 06+ (Officer) - Brown Camo";
     hiddenSelectionsTextures[] =
     {
         QPATHTOF(data\helmets\phase2Pilot\camo\brown\Officer_camo1_co.paa),
@@ -53,7 +53,7 @@ class CLASS(Helmet_Phase2_Pilot_Officer_CamoBrown): CLASS(Helmet_Phase2_Pilot_CX
 };
 class CLASS(Helmet_Phase2_Pilot_Officer_CamoGrey): CLASS(Helmet_Phase2_Pilot_CXE)
 {
-    displayName = "[KC] AVI P2 Helm 11+ (Officer) - Grey Camo";
+    displayName = "[KC] AVI P2 Helm 06+ (Officer) - Grey Camo";
     hiddenSelectionsTextures[] =
     {
         QPATHTOF(data\helmets\phase2Pilot\camo\grey\Officer_camo1_co.paa),

--- a/addons/armor/configs/Uniforms.hpp
+++ b/addons/armor/configs/Uniforms.hpp
@@ -258,7 +258,7 @@ class CLASS(Uniform_CXA): CLASS(Uniform_Base)
 
 class CLASS(Uniform_CXE): CLASS(Uniform_Base)
 {
-    displayName = "[KC] AVI Armor 11 (Ensign)";
+    displayName = "[KC] AVI Armor 06 (Ensign)";
 
     class ItemInfo: ItemInfo
     {

--- a/addons/armor/configs/Units_P2_Pilot.hpp
+++ b/addons/armor/configs/Units_P2_Pilot.hpp
@@ -23,7 +23,7 @@ class CLASS(Unit_Phase2_CXA): CLASS(Unit_Phase2_Base)
 
 class CLASS(Unit_Phase2_CXE): CLASS(Unit_Phase2_CXA)
 {
-    displayName = "AVI P2 Pilot 11 (Ensign)";
+    displayName = "AVI P2 Pilot 06 (Ensign)";
     editorPreview = EDITOR_PREVIEW(Unit_Phase2_CXE);
     icon = "iconManOfficer";
 

--- a/addons/armor/configs/Vests_Airborne.hpp
+++ b/addons/armor/configs/Vests_Airborne.hpp
@@ -78,7 +78,7 @@ class CLASS(Vest_Airborne_CT_Light): CLASS(Vest_Basic)
 
 class CLASS(Vest_Airborne_CS_Light): CLASS(Vest_Airborne_CT_Light)
 {
-    displayName = "[KC] AB Vest 06 (Sergeant, Light)";
+    displayName = "[KC] AB Vest 06 (NCO, Light)";
     hiddenSelectionsTextures[] =
     {
         QPATHTOF(data\vests\infantry\heavy\Accessories_camo1_co.paa), // Holster
@@ -90,7 +90,7 @@ class CLASS(Vest_Airborne_CS_Light): CLASS(Vest_Airborne_CT_Light)
 
 class CLASS(Vest_Airborne_LifeSaver): CLASS(Vest_Medic)
 {
-    displayName = "[KC] AB MED Vest 01+ (Life Saver)";
+    displayName = "[KC] AB MED Vest 01 (Life Saver)";
     model = "\SWLB_CEE\data\SWLB_CEE_Airborne_CFR.p3d";
     hiddenSelections[] = {"camo1", "camo2", "ammo", "pauldron"};
     hiddenSelectionsTextures[] =
@@ -111,7 +111,7 @@ class CLASS(Vest_Airborne_LifeSaver): CLASS(Vest_Medic)
 
 class CLASS(Vest_Airborne_LifeSaverNCO): CLASS(Vest_Airborne_LifeSaver)
 {
-    displayName = "[KC] AB MED Vest 04+ (NCO Life Saver)";
+    displayName = "[KC] AB MED Vest 04 (NCO Life Saver)";
     hiddenSelectionsTextures[] =
     {
         QPATHTOF(data\vests\infantry\heavy\Medic_v2_camo1_co.paa),

--- a/addons/armor/configs/Vests_Airborne.hpp
+++ b/addons/armor/configs/Vests_Airborne.hpp
@@ -67,6 +67,7 @@ class CLASS(Vest_Airborne_CT_Light): CLASS(Vest_Basic)
         QPATHTOF(data\vests\infantry\heavy\Accessories_camo1_co.paa), // Ammo
         ""                                                            // Pauldron
     };
+    picture = "\SWLB_clones\data\ui\icon_SWLB_clone_airborne_armor_ca.paa";
 
     class ItemInfo: ItemInfo
     {

--- a/addons/armor/configs/Vests_Engineer.hpp
+++ b/addons/armor/configs/Vests_Engineer.hpp
@@ -1,6 +1,6 @@
 class CLASS(Vest_Engineer_CT): CLASS(Vest_Basic)
 {
-    displayName = "[KC] ENG Vest 01+ (Trooper)";
+    displayName = "[KC] ENG Vest 01 (Trooper)";
 
     model = "\SWLB_CEE\data\SWLB_CEE_Engineer_Vest.p3d";
     hiddenSelections[] = {"camo1", "camo2"};
@@ -20,7 +20,7 @@ class CLASS(Vest_Engineer_CT): CLASS(Vest_Basic)
 
 class CLASS(Vest_Engineer_CS): CLASS(Vest_CS)
 {
-    displayName = "[KC] ENG Vest 06+ (NCO)";
+    displayName = "[KC] ENG Vest 06 (NCO)";
 
     model = "\SWLB_CEE\data\SWLB_CEE_Engineer_Vest_NCO.p3d";
     hiddenSelections[] = {"camo1", "camo2", "camo3", "camo4", "camo5", "camo6", "ammo"};
@@ -44,7 +44,7 @@ class CLASS(Vest_Engineer_CS): CLASS(Vest_CS)
 
 class CLASS(Vest_Engineer_Officer): CLASS(Vest_Officer)
 {
-    displayName = "[KC] ENG Vest 12+ (Officer)";
+    displayName = "[KC] ENG Vest 12 (Officer)";
 
     model = "\SWLB_CEE\data\SWLB_CEE_Engineer_Vest_Officer.p3d";
     hiddenSelections[] = {"camo1", "camo2"};

--- a/addons/armor/configs/Vests_Infantry.hpp
+++ b/addons/armor/configs/Vests_Infantry.hpp
@@ -276,7 +276,7 @@ class CLASS(Vest_CSM): CLASS(Vest_CS)
 
 class CLASS(Vest_Officer): CLASS(Vest_Basic)
 {
-    displayName = "[KC] INF Vest 12+ (Officer)";
+    displayName = "[KC] INF Vest 12 (Officer)";
 
     model = "\SWLB_clones\SWLB_clone_officer_armor.p3d";
     hiddenSelections[] = {"camo1"};
@@ -318,7 +318,7 @@ class CLASS(Vest_Officer): CLASS(Vest_Basic)
 
 class CLASS(Vest_Officer_v2): CLASS(Vest_Officer)
 {
-    displayName = "[KC] INF Vest 12+ (Officer, v2)";
+    displayName = "[KC] INF Vest 12 (Officer, v2)";
 
     model = "\SWLB_CEE\data\SWLB_CEE_Officer_Tactical.p3d";
     hiddenSelections[] = {"camo1", "camo2"};


### PR DESCRIPTION
## Description
Fixed and cleaned up names for various items.

##Changes
**Armor**
- Fixed picture for light airborne vests (normal/nco)
- Removed `+` from most item names
- Fixed aviation rank grades
  - Ensign gear was given infantry rank grade (11 -> 6)