### PR TITLE
Fixed auto-eject not working

### DIFF
--- a/addons/core/script_macros.hpp
+++ b/addons/core/script_macros.hpp
@@ -1,5 +1,5 @@
 // Global toggle for compile cache
-#define DISABLE_COMPILE_CACHE
+// #define DISABLE_COMPILE_CACHE
 
 #ifdef __A3_DEBUG__
     #include "\ORA\BNA_KC\addons\core\script_debug.hpp"

--- a/addons/vehicles/CfgEventHandlers.hpp
+++ b/addons/vehicles/CfgEventHandlers.hpp
@@ -40,7 +40,7 @@ class Extended_Killed_EventHandlers
     {
         class GVAR(autoEject)
         {
-            killedServer = QUOTE(_this call FUNC(autoEject));
+            serverKilled = QUOTE(_this call FUNC(autoEject));
         };
     };
 };

--- a/addons/vehicles/XEH_postInitClient.sqf
+++ b/addons/vehicles/XEH_postInitClient.sqf
@@ -16,13 +16,4 @@
             moveOut _unit;
         };
     }] call CBA_fnc_addEventHandler;
-
-    ["ace_unconscious", {
-        params ["_unit", "_state"];
-        private ["_atrt"];
-        TRACE_2("ace_unconscious",_unit,_state);
-
-        _atrt = _unit getVariable [QGVAR(atrt_riding), objNull];
-        _atrt call FUNC(atrt_dismount);
-    }] call CBA_fnc_addEventHandler;
 }] call CBA_fnc_addEventHandler;


### PR DESCRIPTION
## Description
Fixed auto eject not working due to a typo.

## Changes
- Renamed `killedServer` to `serverKilled`