### PR TITLE
Updated jetpack variables / properties

### DIFF
--- a/addons/jetpacks/CfgVehicles.hpp
+++ b/addons/jetpacks/CfgVehicles.hpp
@@ -53,38 +53,35 @@ class CfgVehicles
 
         GVAR(isJetpack) = TRUE;
         GVAR(fuel) = JETPACK_FUEL_DEFAULT;
-        BNA_KC_Jet_speed = JETPACK_SPEED_DEFAULT;     // Jetpack speed, effects how fast you move in the air
-        GVAR(speed) = JETPACK_SPEED_DEFAULT;
-        BNA_KC_Jet_strength = JETPACK_STRENGTH_DEFAULT; // Jetpack strength, effects fast the player rises
-        GVAR(strength) = JETPACK_STRENGTH_DEFAULT;
+        GVAR(speed) = JETPACK_SPEED_DEFAULT;     // Jetpack speed, effects how fast you move in the air
+        GVAR(strength) = JETPACK_STRENGTH_DEFAULT; // Jetpack strength, effects fast the player rises
 
         // Effects
-        BNA_KC_Jet_effectPoints[] = {"effect_left", "effect_right"}; // Points to spawn effects, these come from the JLTS model
-        BNA_KC_Jet_effects[] =
+        GVAR(effectPoints)[] = {"effect_left", "effect_right"}; // Points to spawn effects, these come from the JLTS model
+        GVAR(effects)[] =
         {
             QCLASS(Effects_JetpackFire_Blue),
             QCLASS(Effects_JetpackSmoke)
         };
-        BNA_KC_Jet_effectSound  = QPATHTOF(data\audio\Jetpack_Loop.wss);
-        BNA_KC_Jet_lightColor[] = {0, 0.1, 0.9};
+        GVAR(effectSound)  = QPATHTOF(data\audio\Jetpack_Loop.wss);
+        GVAR(lightColor)[] = {0, 0.1, 0.9};
 
-        BNA_KC_Jet_freefallHeight = 500;
+        GVAR(freefallHeight) = 500;
     };
 
     class CLASS(Jetpack_CDV21): CLASS(Jetpack_JT12)
     {
-        BNA_KC_Jet_strength = 0;
         GVAR(strength) = 0;
     };
 
     class CLASS(Jetpack_CDV19): CLASS(Jetpack_JT12)
     {
-        BNA_KC_Jet_effectPoints[] = {"effect"};
+        GVAR(effectPoints)[] = {"effect"};
     };
 
     class CLASS(Jetpack_Droid): CLASS(Jetpack_JT12)
     {
-        BNA_KC_Jet_freefallHeight = 100000;
+        GVAR(freefallHeight) = 100000;
     };
 
     class CLASS(Resupply_Base);

--- a/addons/jetpacks/data/functions/Main/fn_effectHandler.sqf
+++ b/addons/jetpacks/data/functions/Main/fn_effectHandler.sqf
@@ -24,7 +24,7 @@ params ["_unit"];
 private ["_jetpack", "_totalEffects", "_remainingSlots", "_effectPoints", "_effectTypes", "_defaultColor", "_lightColor"];
 if !(hasInterface) exitWith {};
 
-_totalEffects = missionNamespace getVariable ["BNA_KC_Jet_totalEffects", 0];
+_totalEffects = missionNamespace getVariable [QGVAR(totalEffects), 0];
 if (_totalEffects >= GVAR(particleLimit)) exitWith {};
 
 // Don't play effects for units on the ground or who can't jetpack
@@ -33,10 +33,10 @@ if (!(_unit call FUNC(canJetpack)) or isTouchingGround _unit) exitWith {};
 _jetpack = backpack _unit;
 
 // Obtain effect point names
-_effectPoints = GET_ARRAY(configFile >> "CfgVehicles" >> _jetpack >> "BNA_KC_Jet_effectPoints",[]);
-_effectTypes  = GET_ARRAY(configFile >> "CfgVehicles" >> _jetpack >> "BNA_KC_Jet_effects",[]);
+_effectPoints = GET_ARRAY(configFile >> "CfgVehicles" >> _jetpack >> QGVAR(effectPoints),[]);
+_effectTypes  = GET_ARRAY(configFile >> "CfgVehicles" >> _jetpack >> QGVAR(effects),[]);
 _defaultColor = [1, 1, 1]; // Can't include [] with commas inside in a macro
-_lightColor   = GET_ARRAY(configFile >> "CfgVehicles" >> _jetpack >> "BNA_KC_Jet_lightColor",_defaultColor);
+_lightColor   = GET_ARRAY(configFile >> "CfgVehicles" >> _jetpack >> QGVAR(lightColor),_defaultColor);
 if (_effectPoints isEqualTo []) exitWith {}; // Don't spawn effects if there aren't any effect points
 
 if (_totalEffects + (count _effectTypes * count _effectPoints) > GVAR(particleLimit)) then
@@ -102,9 +102,9 @@ if (_totalEffects + (count _effectTypes * count _effectPoints) > GVAR(particleLi
         _unit setVariable [QGVAR(effectSources), _effectSources, true];
 
         // Update total effects, used for setting a cap of jetpack effects
-        private _totalEffects = missionNamespace getVariable ["BNA_KC_Jet_totalEffects", 0];
+        private _totalEffects = missionNamespace getVariable [QGVAR(totalEffects), 0];
         _totalEffects = _totalEffects + count _effectSources;
-        missionNamespace setVariable ["BNA_KC_Jet_totalEffects", _totalEffects, true];
+        missionNamespace setVariable [QGVAR(totalEffects), _totalEffects, true];
     },
     [_unit, _effectPoints, _effectTypes, _lightColor],
     0.15

--- a/addons/jetpacks/data/functions/Main/fn_frameHandler.sqf
+++ b/addons/jetpacks/data/functions/Main/fn_frameHandler.sqf
@@ -51,8 +51,8 @@ if (!(ace_player call FUNC(canJetpack)) or isTouchingGround ace_player) exitWith
 
 // Jetpack properties
 private _jetpack = backpack ace_player;
-private _jetSpeed = GET_NUMBER(configFile >> "CfgVehicles" >> _jetpack >> "BNA_KC_Jet_speed",JETPACK_SPEED_DEFAULT);
-private _jetStrength = GET_NUMBER(configFile >> "CfgVehicles" >> _jetpack >> "BNA_KC_Jet_strength",JETPACK_STRENGTH_DEFAULT);
+private _jetSpeed = GET_NUMBER(configFile >> "CfgVehicles" >> _jetpack >> QGVAR(speed),JETPACK_SPEED_DEFAULT);
+private _jetStrength = GET_NUMBER(configFile >> "CfgVehicles" >> _jetpack >> QGVAR(strength),JETPACK_STRENGTH_DEFAULT);
 
 // Speed, position, and direction
 // Used for calculating mid-air movement

--- a/addons/jetpacks/data/functions/Main/fn_jetpack.sqf
+++ b/addons/jetpacks/data/functions/Main/fn_jetpack.sqf
@@ -26,8 +26,8 @@ if !(ace_player call FUNC(canJetpack)) exitWith {
 
 // Jetpack properties
 private _jetpack = backpack ace_player;
-private _jetStrength = GET_NUMBER(configFile >> "CfgVehicles" >> _jetpack >> "BNA_KC_Jet_strength",JETPACK_STRENGTH_DEFAULT);
-private _freefallHeight = GET_NUMBER(configFile >> "CfgVehicles" >> _jetpack >> "BNA_KC_Jet_freefallHeight",-1);
+private _jetStrength = GET_NUMBER(configFile >> "CfgVehicles" >> _jetpack >> QGVAR(strength),JETPACK_STRENGTH_DEFAULT);
+private _freefallHeight = GET_NUMBER(configFile >> "CfgVehicles" >> _jetpack >> QGVAR(freefallHeight),-1);
 
 ace_player setUnitFreefallHeight _freefallHeight;
 

--- a/addons/jetpacks/data/functions/Main/fn_soundHandler.sqf
+++ b/addons/jetpacks/data/functions/Main/fn_soundHandler.sqf
@@ -25,7 +25,7 @@ if (!(ace_player call FUNC(canJetpack)) or isTouchingGround ace_player) exitWith
 private _jetpack = backpack ace_player;
 
 // Get path to sound effect
-private _sound = GET_STRING(configFile >> "CfgVehicles" >> _jetpack >> "BNA_KC_Jet_effectSound","");
+private _sound = GET_STRING(configFile >> "CfgVehicles" >> _jetpack >> QGVAR(effectSound),"");
 private _volume = 0.05; // Increase volume for each movement key (including slow fall and rising)
 
 _volumeCoef =


### PR DESCRIPTION
## Description
Update jetpack properties / variables to updated format (`BNA_KC_Jet_x` -> `BNA_KC_jetpacks_x`). Fixed jetpack effects not spawning after being used a couple times in a mission.

## Changes
**Jetpacks**
- Updated freefallHeight
- Updated lightColor
- Updated effectSound
- Updated effects
- Updated effectPoints
- Updated totalEffects
  - Mix of old and new names caused issue where effects would not be spawned after a couple uses of the jetpacks
- Updated speed
- Updated strength