### PR TITLE
Jammers - Vanilla Hash and moved interfence handling to client PFH

### DIFF
--- a/addons/jammers/XEH_PREP.hpp
+++ b/addons/jammers/XEH_PREP.hpp
@@ -1,5 +1,6 @@
 PREP(addJammer);
 PREP(addJammerServer);
+PREP(jammerHandlerClient);
 PREP(jammerHandlerServer);
 PREP(updateInterference);
 PREP(removeJammer);

--- a/addons/jammers/XEH_postInitClient.sqf
+++ b/addons/jammers/XEH_postInitClient.sqf
@@ -1,6 +1,7 @@
 #include "script_component.hpp"
 
 GVAR(activeJammers) = createHashmap;
+GVAR(jammerHandler) = -1;
 GVAR(interferenceFactor) = 0.625;
 
 ["CBA_settingsInitialized", {
@@ -9,6 +10,10 @@ GVAR(interferenceFactor) = 0.625;
         TRACE_4("addJammerLocal",_hash,_jammer,_radius,_strength);
         if (isServer) exitWith {}; // For singleplayer
         GVAR(activeJammers) set [_hash, [_jammer, _radius, _strength]];
+
+        if (GVAR(jammerHandler) < 0) then {
+            GVAR(jammerHandler) = [] call FUNC(jammerHandlerClient);
+        };
     }] call CBA_fnc_addEventHandler;
 
     [QGVAR(removeJammerLocal), {
@@ -17,6 +22,4 @@ GVAR(interferenceFactor) = 0.625;
         if (isServer) exitWith {};
         GVAR(activeJammers) deleteAt _hash;
     }] call CBA_fnc_addEventHandler;
-
-    [QGVAR(updateInterference), LINKFUNC(updateInterference)] call CBA_fnc_addEventHandler;
 }] call CBA_fnc_addEventHandler;

--- a/addons/jammers/XEH_postInitClient.sqf
+++ b/addons/jammers/XEH_postInitClient.sqf
@@ -1,7 +1,7 @@
 #include "script_component.hpp"
 
 GVAR(activeJammers) = createHashmap;
-GVAR(jammerHandler) = -1;
+GVAR(jammerHandlerClient) = -1;
 GVAR(interferenceFactor) = 0.625;
 
 ["CBA_settingsInitialized", {
@@ -11,8 +11,8 @@ GVAR(interferenceFactor) = 0.625;
         if (isServer) exitWith {}; // For singleplayer
         GVAR(activeJammers) set [_hash, [_jammer, _radius, _strength]];
 
-        if (GVAR(jammerHandler) < 0) then {
-            GVAR(jammerHandler) = [] call FUNC(jammerHandlerClient);
+        if (GVAR(jammerHandlerClient) < 0) then {
+            GVAR(jammerHandlerClient) = [] call FUNC(jammerHandlerClient);
         };
     }] call CBA_fnc_addEventHandler;
 

--- a/addons/jammers/XEH_postInitClient.sqf
+++ b/addons/jammers/XEH_postInitClient.sqf
@@ -1,21 +1,21 @@
 #include "script_component.hpp"
 
-GVAR(activeJammers) = [] call CBA_fnc_hashCreate;
+GVAR(activeJammers) = createHashmap;
 GVAR(interferenceFactor) = 0.625;
 
 ["CBA_settingsInitialized", {
     [QGVAR(addJammerLocal), {
-        params ["_jammer", "_radius", "_strength"];
-        TRACE_3("addJammerLocal",_jammer,_radius,_strength);
+        params ["_hash", "_jammer", "_radius", "_strength"];
+        TRACE_4("addJammerLocal",_hash,_jammer,_radius,_strength);
         if (isServer) exitWith {}; // For singleplayer
-        [GVAR(activeJammers), _jammer, [_radius, _strength]] call CBA_fnc_hashSet;
+        GVAR(activeJammers) set [_hash, [_jammer, _radius, _strength]];
     }] call CBA_fnc_addEventHandler;
 
     [QGVAR(removeJammerLocal), {
-        params ["_jammer"];
-        TRACE_1("removeJammerLocal",_jammer);
+        params ["_hash"];
+        TRACE_1("removeJammerLocal",_hash);
         if (isServer) exitWith {};
-        [GVAR(activeJammers), _jammer] call CBA_fnc_hashRem;
+        GVAR(activeJammers) deleteAt _hash;
     }] call CBA_fnc_addEventHandler;
 
     [QGVAR(updateInterference), LINKFUNC(updateInterference)] call CBA_fnc_addEventHandler;

--- a/addons/jammers/XEH_postInitServer.sqf
+++ b/addons/jammers/XEH_postInitServer.sqf
@@ -1,7 +1,7 @@
 #include "script_component.hpp"
 
 GVAR(activeJammers) = createHashmap;
-GVAR(jammerHandler) = -1;
+GVAR(jammerHandlerServer) = -1;
 
 ["CBA_settingsInitialized", {
     [QGVAR(addJammer), LINKFUNC(addJammerServer)] call CBA_fnc_addEventHandler;

--- a/addons/jammers/XEH_postInitServer.sqf
+++ b/addons/jammers/XEH_postInitServer.sqf
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 
-GVAR(activeJammers) = [] call CBA_fnc_hashCreate;
+GVAR(activeJammers) = createHashmap;
 GVAR(jammerHandler) = -1;
 
 ["CBA_settingsInitialized", {

--- a/addons/jammers/functions/fnc_addJammerServer.sqf
+++ b/addons/jammers/functions/fnc_addJammerServer.sqf
@@ -19,21 +19,23 @@
  */
 
 params ["_jammer", "_radius", "_strength", "_isActive"];
+private ["_hash"];
 TRACE_4("fnc_addJammerServer",_jammer,_radius,_strength,_isActive);
 
 if (!isServer or
     {!alive _jammer} or
     {_radius < 0} or
     {_strength < 0} or
-    {[GVAR(activeJammers), _jammer] call CBA_fnc_hashHasKey}
+    {hashValue _jammer in GVAR(activeJammers)}
 ) exitWith {false;};
 
-[GVAR(activeJammers), _jammer, [_radius, _strength]] call CBA_fnc_hashSet;
+_hash = hashValue _jammer;
+GVAR(activeJammers) set [_hash, [_jammer, _radius, _strength]];
 _jammer setVariable [QGVAR(isActive), _isActive, true];
 
 if (GVAR(jammerHandler) < 0) then {
     GVAR(jammerHandler) = [] call FUNC(jammerHandlerServer);
 };
 
-[QGVAR(addJammerLocal), [_jammer, _radius, _strength]] call CBA_fnc_globalEvent;
+[QGVAR(addJammerLocal), [_hash, _jammer, _radius, _strength]] call CBA_fnc_globalEvent;
 true;

--- a/addons/jammers/functions/fnc_addJammerServer.sqf
+++ b/addons/jammers/functions/fnc_addJammerServer.sqf
@@ -33,8 +33,8 @@ _hash = hashValue _jammer;
 GVAR(activeJammers) set [_hash, [_jammer, _radius, _strength]];
 _jammer setVariable [QGVAR(isActive), _isActive, true];
 
-if (GVAR(jammerHandler) < 0) then {
-    GVAR(jammerHandler) = [] call FUNC(jammerHandlerServer);
+if (GVAR(jammerHandlerServer) < 0) then {
+    GVAR(jammerHandlerServer) = [] call FUNC(jammerHandlerServer);
 };
 
 [QGVAR(addJammerLocal), [_hash, _jammer, _radius, _strength]] call CBA_fnc_globalEvent;

--- a/addons/jammers/functions/fnc_jammerHandlerClient.sqf
+++ b/addons/jammers/functions/fnc_jammerHandlerClient.sqf
@@ -38,7 +38,7 @@ _condition = {
 
 _exitCode = {
     INFO("No active jammers left, removing client PFH.");
-    GVAR(jammerHandler) = -1;
+    GVAR(jammerHandlerClient) = -1;
 };
 
 _jammerHandler = [

--- a/addons/jammers/functions/fnc_jammerHandlerClient.sqf
+++ b/addons/jammers/functions/fnc_jammerHandlerClient.sqf
@@ -25,11 +25,11 @@ _function = {
 
     {
         _y params ["_jammer"];
-        if (isNull _jammer or {!alive _jammer}) then {
-            [_x, _jammer] call FUNC(removeJammerServer);
-            GVAR(activeJammers) deleteAt _x; // Manual removal for null objects
+        if (isNull _jammer) then {
+            GVAR(activeJammers) deleteAt _x;
         };
     } forEach GVAR(activeJammers);
+    [] call FUNC(updateInterference);
 };
 
 _condition = {
@@ -37,7 +37,7 @@ _condition = {
 };
 
 _exitCode = {
-    INFO("No active jammers left, removing server PFH.");
+    INFO("No active jammers left, removing client PFH.");
     GVAR(jammerHandler) = -1;
 };
 

--- a/addons/jammers/functions/fnc_jammerHandlerServer.sqf
+++ b/addons/jammers/functions/fnc_jammerHandlerServer.sqf
@@ -23,21 +23,22 @@ if (!isServer) exitWith {};
 _function = {
     if (isGamePaused) then {continue;};
 
-    [GVAR(activeJammers), {
-        if (!alive _key) then {
-            _key call FUNC(removeJammerServer);
+    {
+        _y params ["_jammer"];
+        if (isNull _jammer or {!alive _jammer}) then {
+            [_x, _jammer] call FUNC(removeJammerServer);
+            GVAR(activeJammers) deleteAt _x; // Manual removal for null objects
         };
-        alive _key;
-    }] call CBA_fnc_hashFilter;
-    [QGVAR(updateInterference)] call CBA_fnc_globalEvent;
+    } forEach GVAR(activeJammers);
+    [QGVAR(updateInterference)] call CBA_fnc_globalEvent; // TODO: Switch to client PFH?
 };
 
 _condition = {
-    [GVAR(activeJammers)] call CBA_fnc_hashSize > 0;
+    count GVAR(activeJammers) > 0;
 };
 
 _exitCode = {
-    INFO("No active jammers left, removing server PFH");
+    INFO("No active jammers left, removing server PFH.");
     GVAR(jammerHandler) = -1;
 };
 

--- a/addons/jammers/functions/fnc_jammerHandlerServer.sqf
+++ b/addons/jammers/functions/fnc_jammerHandlerServer.sqf
@@ -38,7 +38,7 @@ _condition = {
 
 _exitCode = {
     INFO("No active jammers left, removing server PFH.");
-    GVAR(jammerHandler) = -1;
+    GVAR(jammerHandlerServer) = -1;
 };
 
 _jammerHandler = [

--- a/addons/jammers/functions/fnc_removeJammerServer.sqf
+++ b/addons/jammers/functions/fnc_removeJammerServer.sqf
@@ -15,15 +15,14 @@
  * Public: No
  */
 
-params ["_jammer"];
-private ["_index"];
+params ["_hash", "_jammer"];
 TRACE_1("fnc_removeJammerServer",_jammer);
 
 if (!isServer) exitWith {WARNING("fnc_removeJammerServer called from non-server context"); false;};
 if (isNull _jammer) exitWith {false};
 
-[GVAR(activeJammers), _jammer] call CBA_fnc_hashRem;
+GVAR(activeJammers) deleteAt _hash;
 _jammer setVariable [QGVAR(isActive), nil, true];
 
-[QGVAR(removeJammerLocal), _jammer] call CBA_fnc_globalEvent;
+[QGVAR(removeJammerLocal), _hash] call CBA_fnc_globalEvent;
 true;

--- a/addons/jammers/functions/fnc_updateInterference.sqf
+++ b/addons/jammers/functions/fnc_updateInterference.sqf
@@ -15,20 +15,20 @@
  * Public: No
  */
 
-private ["_fnc_updateInterference"];
+private ["_averageInterference"];
 if (!hasInterface) exitWith {};
 
 INFO_1("Updating interference for %1",ace_player);
 
-// Jammers are tracked separately on server/client - Might no longer be necessary after using CBA hash
-// GVAR(activeJammers) = GVAR(activeJammers) select {!isNull (_x#0)};
-
 _averageInterference = 1;
 
-_fnc_updateInterference = {
-    private ["_jammer", "_distance", "_distanceFactor", "_signal", "_interference"];
-    _jammer = _key;
-    _value params ["_radius", "_strength"];
+{
+    (GVAR(activeJammers) get _x) params ["_jammer", "_radius", "_strength"];
+    private ["_distance", "_distanceFactor", "_signal", "_interference"];
+
+    if (isNull _jammer) then {
+        GVAR(activeJammers) deleteAt _x;
+    };
 
     if !(_jammer getVariable [QGVAR(isActive), false]) then {continue;};
 
@@ -46,9 +46,7 @@ _fnc_updateInterference = {
         };
     };
     TRACE_7("updateInterference",_radius,_strength,_distance,_distanceFactor,_signal,_interference,_averageInterference);
-};
-
-[GVAR(activeJammers), _fnc_updateInterference] call CBA_fnc_hashEachPair;
+} forEach keys GVAR(activeJammers);
 
 _averageInterference = 0.1 max _averageInterference;
 ace_player setVariable ["tf_receivingDistanceMultiplicator", _averageInterference];


### PR DESCRIPTION
## Description
Refactored jammers to use vanilla hash map instead of a CBA hashmap. Moved global event to update interference to client PFH.

## Changes
**Jammers**
- Updated `activeJammers` to use vanilla hashmap.
  - `hashValue` of object is used as the key.
- Changed globalEvent to client PFH for updating interference.