### PR TITLE
Armor - Crewmen vests

### DIFF
--- a/.hemtt/presets/main.html
+++ b/.hemtt/presets/main.html
@@ -237,6 +237,15 @@
             <a href="http://steamcommunity.com/sharedfiles/filedetails/?id=2332457910" data-type="Link">http://steamcommunity.com/sharedfiles/filedetails/?id=2332457910</a>
           </td>
         </tr>
+        <tr data-type="ModContainer">
+          <td data-type="DisplayName">Schlabbies Depressed Textures (Legion Base)</td>
+          <td>
+            <span class="from-steam">Steam</span>
+          </td>
+          <td>
+            <a href="http://steamcommunity.com/sharedfiles/filedetails/?id=1686872930" data-type="Link">http://steamcommunity.com/sharedfiles/filedetails/?id=1686872930</a>
+          </td>
+        </tr>
       </table>
     </div>
     <div class="dlc-list">

--- a/.hemtt/project.toml
+++ b/.hemtt/project.toml
@@ -42,7 +42,7 @@ workshop = [
     "623475643",  # 3DEN
     "1779063631", # ZEN
     "2018593688", # ZEN ACE Compat
-    # "1686872930", # SDT # ! Not currently used
+    "1686872930", # SDT
     "2567352444", # WBK Droids # TODO: Move assets to aux itself
     "2522638637", # ACE Arsenal Extended
     "1572627279", # OPTRE First Contact
@@ -63,7 +63,7 @@ workshop = [
     "623475643",  # 3DEN
     "1779063631", # ZEN
     "2018593688", # ZEN ACE Compat
-    # "1686872930", # SDT # ! Not currently used
+    "1686872930", # SDT
     "2567352444", # WBK Droids # TODO: Move assets to aux
     "1572627279", # OPTRE First Contact
     "2915485125", # Burn 'Em

--- a/addons/armor/CfgGlasses.hpp
+++ b/addons/armor/CfgGlasses.hpp
@@ -1,3 +1,11 @@
+#define OVERLAY_P1 ACE_Overlay = "\lsd_equipment_bluefor\accessories\gar\interiorHud\data\p1_hud_ca.paa"; \
+ACE_OverlayCracked = "\lsd_equipment_bluefor\accessories\gar\interiorHud\data\p1_hud_cracked_ca.paa"; \
+ACE_OverlayDirt = "\lsd_equipment_bluefor\accessories\gar\interiorHud\data\p1_hud_dirty_ca.paa"
+
+#define OVERLAY_P2 ACE_Overlay = "\lsd_equipment_bluefor\accessories\gar\interiorHud\data\p2_hud_ca.paa"; \
+ACE_OverlayCracked = "\lsd_equipment_bluefor\accessories\gar\interiorHud\data\p2_hud_cracked_ca.paa"; \
+ACE_OverlayDirt = "\lsd_equipment_bluefor\accessories\gar\interiorHud\data\p2_hud_dirty_ca.paa"
+
 class CfgGlasses {
     class ls_combatGoggles_base;
     class CLASS(Facewear_ARF_Flaps): ls_combatGoggles_base {
@@ -15,20 +23,22 @@ class CfgGlasses {
             "" // Visor
         };
         picture = QPATHTOF(data\ui\Facewear_ARF_Flaps_ca.paa);
-
-        ACE_Overlay = "\SWLB_equipment\facewears\data\P2_HUD_ca.paa";
-        ACE_OverlayCracked = "\SWLB_equipment\facewears\data\P2_HUD_cracked_ca.paa";
-        ACE_OverlayDirt = "\A3\Ui_f\data\IGUI\RscTitles\HealthTextures\dust_upper_ca.paa";
-        ACE_DustPath = "\z\ace\addons\goggles\textures\fx\dust\%1.paa";
+        OVERLAY_P2;
     };
 
-    class CLASS(Facewear_phase2_Pauldron): CLASS(Facewear_ARF_Flaps) {
-        displayName = "[KC] Pauldron";
+    class CLASS(Facewear_phase1_Pauldron): CLASS(Facewear_ARF_Flaps) {
+        displayName = "[KC] Pauldron (P1)";
         model = "\SWLB_clones\SWLB_clone_lieutenant_armor.p3d";
         hiddenSelections[] = {"camo1"};
         hiddenSelectionsTextures[] = {
             QPATHTOF(data\vests\infantry\officer\Officer_camo1_co.paa) // Pauldron
         };
         picture = "\SWLB_clones\data\ui\icon_SWLB_clone_officer_armor_ca.paa";
+        OVERLAY_P1;
+    };
+
+    class CLASS(Facewear_phase2_Pauldron): CLASS(Facewear_phase1_Pauldron) {
+        displayName = "[KC] Pauldron (P2)";
+        OVERLAY_P2;
     };
 };

--- a/addons/armor/CfgGlasses.hpp
+++ b/addons/armor/CfgGlasses.hpp
@@ -1,8 +1,6 @@
-class CfgGlasses
-{
+class CfgGlasses {
     class ls_combatGoggles_base;
-    class CLASS(Facewear_ARF_Flaps): ls_combatGoggles_base
-    {
+    class CLASS(Facewear_ARF_Flaps): ls_combatGoggles_base {
         SCOPE_PUBLIC;
         author = AUTHOR;
 
@@ -18,9 +16,19 @@ class CfgGlasses
         };
         picture = QPATHTOF(data\ui\Facewear_ARF_Flaps_ca.paa);
 
-        ACE_DustPath = "\z\ace\addons\goggles\textures\fx\dust\%1.paa";
         ACE_Overlay = "\SWLB_equipment\facewears\data\P2_HUD_ca.paa";
         ACE_OverlayCracked = "\SWLB_equipment\facewears\data\P2_HUD_cracked_ca.paa";
         ACE_OverlayDirt = "\A3\Ui_f\data\IGUI\RscTitles\HealthTextures\dust_upper_ca.paa";
+        ACE_DustPath = "\z\ace\addons\goggles\textures\fx\dust\%1.paa";
+    };
+
+    class CLASS(Facewear_phase2_Pauldron): CLASS(Facewear_ARF_Flaps) {
+        displayName = "[KC] Pauldron";
+        model = "\SWLB_clones\SWLB_clone_lieutenant_armor.p3d";
+        hiddenSelections[] = {"camo1"};
+        hiddenSelectionsTextures[] = {
+            QPATHTOF(data\vests\infantry\officer\Officer_camo1_co.paa) // Pauldron
+        };
+        picture = "\SWLB_clones\data\ui\icon_SWLB_clone_officer_armor_ca.paa";
     };
 };

--- a/addons/armor/CfgWeapons.hpp
+++ b/addons/armor/CfgWeapons.hpp
@@ -102,6 +102,7 @@ class CfgWeapons
     #include "configs\Vests_Infantry.hpp"
     #include "configs\Vests_Airborne.hpp"
     #include "configs\Vests_Engineer.hpp"
+    #include "configs\Vests_Tanker.hpp"
     #include "configs\Vests_ARC.hpp"
     #include "configs\Vests_Commando.hpp"
 

--- a/addons/armor/XtdGearModels.hpp
+++ b/addons/armor/XtdGearModels.hpp
@@ -750,6 +750,24 @@ class XtdGearModels
             };
         };
 
+        class CLASS(Vests_Tanker): CLASS(Helmets_Phase1) {
+            label = "Tanker Vests";
+            options[] = {"rank"};
+
+            class rank {
+                changeInGame = FALSE;
+                values[] = {
+                    "CT",
+                    "CS",
+                    "WO"
+                };
+
+                class CT { label = "Trooper"; };
+                class CS { label = "NCO"; };
+                class WO { label = "Officer"; };
+            };
+        };
+
         class CLASS(Vests_ARC): CLASS(Helmets_Phase1)
         {
             label = "ARC Vests";

--- a/addons/armor/config.cpp
+++ b/addons/armor/config.cpp
@@ -17,7 +17,8 @@ class CfgPatches
             "SWLB_Clones",
             "SWLB_CEE",
             "JLTS_core",
-            "JLTS_characters_CloneArmor2"
+            "JLTS_characters_CloneArmor2",
+            "SDT_gear"
         };
         units[] =
         {
@@ -393,6 +394,9 @@ class CfgPatches
             QCLASS(Vest_Engineer_CT),
             QCLASS(Vest_Engineer_CS),
             QCLASS(Vest_Engineer_Officer),
+            QCLASS(Vest_Tanker_CT),
+            QCLASS(Vest_Tanker_CS),
+            QCLASS(Vest_Tanker_WO),
             QCLASS(Vest_ARC),
             QCLASS(Vest_ARC_Light),
             QCLASS(Vest_ARC_v2),

--- a/addons/armor/configs/Vests_Tanker.hpp
+++ b/addons/armor/configs/Vests_Tanker.hpp
@@ -1,0 +1,49 @@
+class CLASS(Vest_Tanker_CT): CLASS(Vest_Basic) {
+    displayName = "[KC] ARMR Vest 01 (Enlisted)";
+
+    model = "\SDT_gear\SDT_gunner_vest.p3d";
+    hiddenSelections[] = {"camo1"};
+    hiddenSelectionsTextures[] = {"\SDT_gear\data\Vests\chestplate_silver.paa"};
+    picture = "\SWLB_clones\data\ui\icon_SWLB_clone_airborne_armor_ca.paa";
+
+    class ItemInfo: ItemInfo {
+        uniformModel = "\SDT_gear\SDT_gunner_vest.p3d";
+        hiddenSelections[] = {"camo1"};
+    };
+};
+
+class CLASS(Vest_Tanker_CS): CLASS(Vest_Tanker_CT) {
+    displayName = "[KC] ARMR Vest 02 (NCO)";
+
+    model = "\SDT_gear\SDT_gunner_recon_vest.p3d";
+    hiddenSelections[] = {"camo1", "camo2", "holster", "pauldron"};
+    hiddenSelectionsTextures[] = {
+        "\SDT_gear\data\Vests\chestplate_silver.paa",
+        QPATHTOF(data\vests\infantry\heavy\Accessories_camo1_co.paa), // Chest Strap
+        QPATHTOF(data\vests\infantry\heavy\Accessories_camo1_co.paa), // Holster
+        QPATHTOF(data\vests\infantry\heavy\Accessories_camo1_co.paa)  // Pauldron
+    };
+    picture = "\SWLB_clones\data\ui\icon_SWLB_clone_airborne_nco_armor_ca.paa";
+
+    class ItemInfo: ItemInfo {
+        uniformModel = "\SDT_gear\SDT_gunner_recon_vest.p3d";
+        hiddenSelections[] = {"camo1", "camo2", "holster", "pauldron"};
+    };
+};
+
+class CLASS(Vest_Tanker_WO): CLASS(Vest_Tanker_CT) {
+    displayName = "[KC] ARMR Vest 03 (Officer)";
+
+    model = "\SDT_gear\SDT_gunner_NCO_vest.p3d";
+    hiddenSelections[] = {"camo1", "camo2"};
+    hiddenSelectionsTextures[] = {
+        "\SDT_gear\data\Vests\chestplate_silver.paa",
+        QPATHTOF(data\vests\infantry\officer\Officer_camo1_co.paa) // Kama
+    };
+    picture = "\SWLB_clones\data\ui\icon_SWLB_clone_kama_armor_ca.paa";
+
+    class ItemInfo: ItemInfo {
+        uniformModel = "\SDT_gear\SDT_gunner_NCO_vest.p3d";
+        hiddenSelections[] = {"camo1", "camo2"};
+    };
+};

--- a/addons/armor/configs/Vests_Tanker.hpp
+++ b/addons/armor/configs/Vests_Tanker.hpp
@@ -10,6 +10,11 @@ class CLASS(Vest_Tanker_CT): CLASS(Vest_Basic) {
         uniformModel = "\SDT_gear\SDT_gunner_vest.p3d";
         hiddenSelections[] = {"camo1"};
     };
+
+    class XtdGearInfo {
+        model = QCLASS(Vests_Tanker);
+        rank = "CT";
+    };
 };
 
 class CLASS(Vest_Tanker_CS): CLASS(Vest_Tanker_CT) {
@@ -29,6 +34,10 @@ class CLASS(Vest_Tanker_CS): CLASS(Vest_Tanker_CT) {
         uniformModel = "\SDT_gear\SDT_gunner_recon_vest.p3d";
         hiddenSelections[] = {"camo1", "camo2", "holster", "pauldron"};
     };
+
+    class XtdGearInfo: XtdGearInfo {
+        rank = "CS";
+    };
 };
 
 class CLASS(Vest_Tanker_WO): CLASS(Vest_Tanker_CT) {
@@ -45,5 +54,9 @@ class CLASS(Vest_Tanker_WO): CLASS(Vest_Tanker_CT) {
     class ItemInfo: ItemInfo {
         uniformModel = "\SDT_gear\SDT_gunner_NCO_vest.p3d";
         hiddenSelections[] = {"camo1", "camo2"};
+    };
+
+    class XtdGearInfo: XtdGearInfo {
+        rank = "WO";
     };
 };


### PR DESCRIPTION
## Description
Added armored vests from Schlabbie's Depressed Textures for use by Reeker crewmen.

## Changes
- Added Enlisted, NCO, and Officer variants of tanker vests.
- Added P1/P2 visor facewear versions of the KC pauldron