### PR TITLE
Vehicles - Fixed missing seat type in `fnc_canSpawnCrew`

### DIFF
--- a/addons/vehicles/functions/fnc_canSpawnCrew.sqf
+++ b/addons/vehicles/functions/fnc_canSpawnCrew.sqf
@@ -27,5 +27,5 @@ if (isNull _vehicle or {!(ace_player in _crew)}) exitWith {false};
 _emptyCrewSeats = 0;
 {
     _emptyCrewSeats = _emptyCrewSeats + (_vehicle emptyPositions _x);
-} forEach ["Commander", "Driver", "Gunner"];
+} forEach ["Commander", "Driver", "Gunner", "Turret"];
 _emptyCrewSeats > 0;


### PR DESCRIPTION
## Description
Fixed `"Turret"` seat type missing from `fnc_canSpawnCrew`. Made it so that some vehicles could not spawn crew when they should be able to, like the ARC-170.